### PR TITLE
Add Docker automated builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker Build and Run
+
+on:
+  push:
+    branches:
+      - main
+      # dev
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docker-build-and-run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/app:${{ github.sha }}
+          build-args: |
+            VITE_TESTNET_PUBLIC_RPC=${{ secrets.VITE_TESTNET_PUBLIC_RPC }}
+            VITE_MAINNET_PUBLIC_RPC=${{ secrets.VITE_MAINNET_PUBLIC_RPC }}
+            VITE_ALCHEMY_KEY=${{ secrets.VITE_ALCHEMY_KEY }}
+            VITE_WALLETCONNECT_ID=${{ secrets.VITE_WALLETCONNECT_ID }}
+
+      - name: Pull and run Docker image
+        run: |
+          docker pull ghcr.io/${{ github.repository_owner }}/app:${{ github.sha }}
+          docker run -d -p 80:80 ghcr.io/${{ github.repository_owner }}/app:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Using same node version as in the CI/CD pipeline
+FROM node:18.7 AS base
+
+WORKDIR /app
+
+COPY package.json ./
+COPY yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+FROM base AS build
+
+COPY . .
+
+# Setting up environment variables
+ARG VITE_TESTNET_PUBLIC_RPC
+ARG VITE_MAINNET_PUBLIC_RPC
+ARG VITE_ALCHEMY_KEY
+ARG VITE_WALLETCONNECT_ID
+
+ENV VITE_TESTNET_PUBLIC_RPC=$VITE_TESTNET_PUBLIC_RPC
+ENV VITE_MAINNET_PUBLIC_RPC=$VITE_MAINNET_PUBLIC_RPC
+ENV VITE_ALCHEMY_KEY=$VITE_ALCHEMY_KEY
+ENV VITE_WALLETCONNECT_ID=$VITE_WALLETCONNECT_ID
+
+# Building the application
+RUN yarn build
+
+FROM nginx:stable-alpine AS production
+
+# Copying the build directory from the 'build' stage to the nginx server
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Expose port 80 to the Docker host, so we can access the application from outside the container
+EXPOSE 80
+
+# When the container starts, nginx starts as well, serving the static files.
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -53,3 +53,36 @@ yarn test:e2e
 ```bash
 yarn test
 ```
+
+## Docker
+
+### Build the image locally
+
+For OP Mainnet:
+
+```bash
+docker build \
+  --build-arg VITE_TESTNET_PUBLIC_RPC= \
+  --build-arg VITE_MAINNET_PUBLIC_RPC=https://optimism.blockpi.network/v1/rpc/public \
+  --build-arg VITE_ALCHEMY_KEY=<your-alchemy-key> \
+  --build-arg VITE_WALLETCONNECT_ID=<your-walletconnect-id> \
+  -t hai-on-op/app:mainnet .
+```
+
+For OP Sepolia:
+
+```bash
+docker build \
+  --build-arg VITE_TESTNET_PUBLIC_RPC=https://optimism-sepolia.blockpi.network/v1/rpc/public \
+  --build-arg VITE_MAINNET_PUBLIC_RPC= \
+  --build-arg VITE_ALCHEMY_KEY=<your-alchemy-key> \
+  --build-arg VITE_WALLETCONNECT_ID=<your-walletconnect-id> \
+  -t hai-on-op/app:testnet .
+```
+
+### Run the image locally
+
+```bash
+docker run -d -p 8080:80 hai-on-op/app:testnet
+```
+


### PR DESCRIPTION
## Description
- Added a Dockerfile w/steps for building the application into a Docker image for dev & prod
- Created docker.yml workflow under .github/workflows to automate the Docker image build process upon pushes to main
- Made sure env variables for the build args are in line w/HAI's .env.example and the Docker builds are named appropriately (hai-on-op/app:testnet for example)
- Added documentation on building and running so anyone can run the app locally w/Docker

## Screenshots

Built locally

<img width="1203" alt="built locally" src="https://github.com/hai-on-op/app/assets/47253537/6e44494e-5578-4c3a-bb2f-291684c7af98">

Running

<img width="1470" alt="runs on 8080" src="https://github.com/hai-on-op/app/assets/47253537/2b4be39b-7cff-4c27-84d7-023e9a341f2a">

