### PR TITLE
chore: hide WBTC vaults in My Vaults table

### DIFF
--- a/src/model/vaultModel.ts
+++ b/src/model/vaultModel.ts
@@ -94,10 +94,14 @@ const DEFAULT_VAULT_DATA: IVaultData = {
     collateral: '',
 }
 
+const DEPRECATED_COLLATERALS: Array<String> = ['WBTC']
+
 export const vaultModel: VaultModel = {
     list: [],
     setList: action((state, payload) => {
-        state.list = payload
+        state.list = payload.filter(
+            ({ collateralName }) => !DEPRECATED_COLLATERALS.includes(collateralName.toUpperCase())
+        )
     }),
     fetchLiquidationData: thunk(async (actions, payload) => {
         const data = await fetchLiquidationData(payload)

--- a/src/model/vaultModel.ts
+++ b/src/model/vaultModel.ts
@@ -94,7 +94,7 @@ const DEFAULT_VAULT_DATA: IVaultData = {
     collateral: '',
 }
 
-const DEPRECATED_COLLATERALS: Array<String> = ['WBTC']
+const DEPRECATED_COLLATERALS: Array<string> = ['WBTC']
 
 export const vaultModel: VaultModel = {
     list: [],


### PR DESCRIPTION
# Hide deprecated WBTC vaults from My Vaults table

## Problem
Some users have empty WBTC vaults from when it was an available collateral. These empty vaults are still appearing in the My Vaults table, which can be confusing for users.

## Solution
Implemented a filter in the vaultModel to exclude deprecated collaterals, specifically WBTC, from the vault list. This approach not only fixes the issue in the My Vaults table but also prevents deprecated vaults from appearing in other parts of the application.

Changes made:
1. Added a `DEPRECATED_COLLATERALS` array to the vaultModel, currently containing 'WBTC'.
2. Modified the `setList` action to filter out vaults with collateral types listed in `DEPRECATED_COLLATERALS`.

## Implementation Details
Added the following code to the vaultModel:

```javascript
const DEPRECATED_COLLATERALS: Array<String> = ['WBTC']

setList: action((state, payload) => {
    state.list = payload.filter(
        ({ collateralName }) => !DEPRECATED_COLLATERALS.includes(collateralName.toUpperCase())
    )
}),
```

## Additional Context
- This change affects all instances where the vault list is used, ensuring consistency across the application.
- The solution is scalable: if more collateral types become deprecated in the future, we can easily add them to the `DEPRECATED_COLLATERALS` array.

## Testing
- Due to the unavailability of a WBTC vault for testing, the implementation was tested using WETH as a substitute.
- Verified that WETH vaults were successfully hidden when added to the `DEPRECATED_COLLATERALS` array.
- The functionality works as expected for WETH, suggesting it should work similarly for WBTC.
- **Note**: Direct testing with WBTC vaults is still needed to verify the fix fully.

## Next Steps
1. Conduct additional testing with accounts that have WBTC vaults to confirm the fix works as intended for the target collateral.
2. Consider setting up a test environment that includes deprecated WBTC vaults for more comprehensive testing in the future.

Please review and let me know if any further changes, clarifications, or additional testing are needed before merging.