### PR TITLE
Feat/remove wbtc from count and dropdowns

### DIFF
--- a/src/components/CollateralDropdown.tsx
+++ b/src/components/CollateralDropdown.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 import { Text } from '~/styles'
 import { BrandedDropdown, DropdownOption } from './BrandedDropdown'
 import { TokenArray } from './TokenArray'
+import { DEPRECATED_COLLATERALS } from '~/utils'
 
 type CollateralDropdownProps = {
     label: string
@@ -18,6 +19,7 @@ export function CollateralDropdown({ label, selectedAsset, onSelect, excludeAll 
 
     const symbols = Object.values(tokensData || {})
         .filter(({ isCollateral }) => isCollateral)
+        .filter(({ symbol }) => !DEPRECATED_COLLATERALS.includes(symbol))
         .map(({ symbol }) => symbol)
 
     return (

--- a/src/containers/Vaults/Manage/ManageDropdown.tsx
+++ b/src/containers/Vaults/Manage/ManageDropdown.tsx
@@ -9,6 +9,7 @@ import { CenteredFlex, Flex, type FlexProps, HaiButton, Text } from '~/styles'
 import { BrandedDropdown, DropdownOption } from '~/components/BrandedDropdown'
 import { TokenArray } from '~/components/TokenArray'
 import { Plus } from 'react-feather'
+import { DEPRECATED_COLLATERALS } from '~/utils'
 
 export function ManageDropdown(props: FlexProps) {
     const {
@@ -21,6 +22,7 @@ export function ManageDropdown(props: FlexProps) {
     const { label, options } = useMemo(() => {
         const symbols = Object.values(tokensData || {})
             .filter(({ isCollateral }) => isCollateral)
+            .filter(({ symbol }) => !DEPRECATED_COLLATERALS.includes(symbol))
             .map(({ symbol }) => symbol)
 
         const sortedVaults = symbols.reduce(

--- a/src/hooks/useAvailableVaults.tsx
+++ b/src/hooks/useAvailableVaults.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { BigNumber } from 'ethers'
 
 import type { AvailableVaultPair, SortableHeader, Sorting } from '~/types'
-import { arrayToSorted } from '~/utils'
+import { arrayToSorted, DEPRECATED_COLLATERALS } from '~/utils'
 import { useStoreState } from '~/store'
 
 const sortableHeaders: SortableHeader[] = [
@@ -43,22 +43,24 @@ export function useAvailableVaults() {
     const HAS_REWARDS = ['APXETH', 'WETH', 'WSTETH', 'RETH', 'OP', 'TBTC']
 
     const availableVaults: AvailableVaultPair[] = useMemo(() => {
-        return collaterals.map((collateral) => {
-            const symbol = collateral.symbol
-            const { liquidationCRatio, totalAnnualizedStabilityFee } =
-                vaultState.liquidationData?.collateralLiquidationData[symbol] || {}
-            return {
-                collateralName: symbol,
-                collateralLabel: collateral.label,
-                // hasRewards: collateral.hasRewards,
-                hasRewards: HAS_REWARDS.includes(symbol),
-                collateralizationFactor: liquidationCRatio || '',
-                stabilityFee: (1 - parseFloat(totalAnnualizedStabilityFee || '1')).toString(),
-                apy: totalAnnualizedStabilityFee || '',
-                eligibleBalance: tokensFetchedData[symbol]?.balanceE18,
-                myVaults: vaultState.list.filter(({ collateralName }) => collateralName === symbol),
-            }
-        })
+        return collaterals
+            .filter(({ symbol }) => !DEPRECATED_COLLATERALS.includes(symbol))
+            .map((collateral) => {
+                const symbol = collateral.symbol
+                const { liquidationCRatio, totalAnnualizedStabilityFee } =
+                    vaultState.liquidationData?.collateralLiquidationData[symbol] || {}
+                return {
+                    collateralName: symbol,
+                    collateralLabel: collateral.label,
+                    // hasRewards: collateral.hasRewards,
+                    hasRewards: HAS_REWARDS.includes(symbol),
+                    collateralizationFactor: liquidationCRatio || '',
+                    stabilityFee: (1 - parseFloat(totalAnnualizedStabilityFee || '1')).toString(),
+                    apy: totalAnnualizedStabilityFee || '',
+                    eligibleBalance: tokensFetchedData[symbol]?.balanceE18,
+                    myVaults: vaultState.list.filter(({ collateralName }) => collateralName === symbol),
+                }
+            })
     }, [symbols, tokensFetchedData, vaultState.list, vaultState.liquidationData])
 
     const [eligibleOnly, setEligibleOnly] = useState(false)


### PR DESCRIPTION
# Remove Deprecated Collaterals from UI Elements

This PR addresses two issues related to deprecated collaterals, specifically WBTC.

## 1. Fix Available Vaults Tab Count

### Changes
- Updated the logic for counting available vaults to exclude deprecated collaterals.
- Ensured the tab count accurately reflects the number of non-deprecated collaterals displayed in the Available Vaults table.

### Impact
- The Available Vaults tab now shows the correct count, excluding deprecated collaterals like WBTC.
- Improved consistency between the tab count and the actual content of the Available Vaults table.

## 2. Remove WBTC from Dropdowns

### Changes
- Removed WBTC from asset dropdowns throughout the application.

### Impact
- Users can no longer select WBTC in asset dropdowns, preventing interactions with deprecated vaults.
- Improved user experience by only presenting active, non-deprecated collateral options.

## Testing
- Verified the correct Available Vaults tab count in various environments.
- Confirmed WBTC's absence from all relevant asset dropdowns.