### PR TITLE
Staking UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
         "@nivo/line": "0.84.0",
         "@nivo/pie": "0.84.0",
         "@rainbow-me/rainbowkit": "1.0.9",
+        "@uniswap/sdk-core": "^7.7.2",
+        "@uniswap/v3-sdk": "^3.25.2",
         "@vercel/analytics": "1.1.2",
         "@vercel/node": "^3.0.24",
         "axios": "0.27.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { VelodromePriceProvider } from './providers/VelodromePriceProvider'
 import { AnalyticsProvider } from '~/providers/AnalyticsProvider'
 import { EffectsProvider } from './providers/EffectsProvider'
 import { ClaimsProvider } from './providers/ClaimsProvider'
+import { LPDataProvider } from './providers/LPDataProvider'
+import { StakingProvider } from './providers/StakingProvider'
 
 import { GlobalStyle } from '~/styles'
 import { ErrorBoundary } from '~/ErrorBoundary'
@@ -23,6 +25,7 @@ import { Contracts } from '~/containers/Contracts'
 import { Learn } from './containers/Learn'
 import { VaultExplorer } from './containers/Vaults/Explore'
 import { TestClaim } from './containers/TestClaim'
+import { Stake } from './containers/Stake'
 import { TestClaimVelo } from './containers/TestClaimVelo'
 import flagsmith from 'flagsmith'
 import { FlagsmithProvider } from 'flagsmith/react'
@@ -44,60 +47,94 @@ const App = () => {
                 <ErrorBoundary>
                     <ApolloProvider client={client}>
                         <VelodromePriceProvider>
-                            <AnalyticsProvider>
-                                <EffectsProvider>
-                                    <ClaimsProvider>
-                                        <Shared>
-                                            <Suspense fallback={null}>
-                                                <Route />
-                                                <>
-                                                    <Switch>
-                                                        {NETWORK_ID === ChainId.OPTIMISM_SEPOLIA && (
-                                                            <Route
-                                                                exact
-                                                                strict
-                                                                component={TestClaim}
-                                                                path={'/test/claim'}
-                                                            />
-                                                        )}
-                                                        {NETWORK_ID === ChainId.OPTIMISM_SEPOLIA && (
-                                                            <Route
-                                                                exact
-                                                                strict
-                                                                component={TestClaimVelo}
-                                                                path={'/test/claim-velo'}
-                                                            />
-                                                        )}
-                                                        <Route exact strict component={Splash} path={'/'} />
-                                                        <Route exact strict component={Auctions} path={'/auctions'} />
-                                                        <Route exact strict component={Analytics} path={'/analytics'} />
-                                                        <Route exact strict component={Contracts} path={'/contracts'} />
-                                                        <Route exact strict component={Learn} path={'/learn'} />
-                                                        <Route exact strict component={Earn} path={'/earn'} />
-                                                        <Route
-                                                            exact
-                                                            strict
-                                                            component={VaultExplorer}
-                                                            path={'/vaults/explore'}
-                                                        />
-                                                        <Route
-                                                            exact
-                                                            strict
-                                                            component={Vaults}
-                                                            path={'/vaults/manage'}
-                                                        />
-                                                        <Route exact strict component={Vaults} path={'/vaults/open'} />
-                                                        <Route exact component={Vaults} path={'/vaults/:idOrOwner'} />
-                                                        <Route exact strict component={Vaults} path={'/vaults'} />
+                            <LPDataProvider>
+                                <StakingProvider>
+                                    <AnalyticsProvider>
+                                        <EffectsProvider>
+                                            <ClaimsProvider>
+                                                <Shared>
+                                                    <Suspense fallback={null}>
+                                                        <Route />
+                                                        <>
+                                                            <Switch>
+                                                                {NETWORK_ID === ChainId.OPTIMISM_SEPOLIA && (
+                                                                    <Route
+                                                                        exact
+                                                                        strict
+                                                                        component={TestClaim}
+                                                                        path={'/test/claim'}
+                                                                    />
+                                                                )}
+                                                                {NETWORK_ID === ChainId.OPTIMISM_SEPOLIA && (
+                                                                    <Route
+                                                                        exact
+                                                                        strict
+                                                                        component={TestClaimVelo}
+                                                                        path={'/test/claim-velo'}
+                                                                    />
+                                                                )}
+                                                                <Route exact strict component={Splash} path={'/'} />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Auctions}
+                                                                    path={'/auctions'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Analytics}
+                                                                    path={'/analytics'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Contracts}
+                                                                    path={'/contracts'}
+                                                                />
+                                                                <Route exact strict component={Learn} path={'/learn'} />
+                                                                <Route exact strict component={Stake} path={'/stake'} />
+                                                                <Route exact strict component={Earn} path={'/earn'} />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={VaultExplorer}
+                                                                    path={'/vaults/explore'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Vaults}
+                                                                    path={'/vaults/manage'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Vaults}
+                                                                    path={'/vaults/open'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    component={Vaults}
+                                                                    path={'/vaults/:idOrOwner'}
+                                                                />
+                                                                <Route
+                                                                    exact
+                                                                    strict
+                                                                    component={Vaults}
+                                                                    path={'/vaults'}
+                                                                />
 
-                                                        <Redirect from="*" to="/" />
-                                                    </Switch>
-                                                </>
-                                            </Suspense>
-                                        </Shared>
-                                    </ClaimsProvider>
-                                </EffectsProvider>
-                            </AnalyticsProvider>
+                                                                <Redirect from="*" to="/" />
+                                                            </Switch>
+                                                        </>
+                                                    </Suspense>
+                                                </Shared>
+                                            </ClaimsProvider>
+                                        </EffectsProvider>
+                                    </AnalyticsProvider>
+                                </StakingProvider>
+                            </LPDataProvider>
                         </VelodromePriceProvider>
                     </ApolloProvider>
                 </ErrorBoundary>

--- a/src/abis/RewardPool.json
+++ b/src/abis/RewardPool.json
@@ -1,0 +1,384 @@
+[
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_rewardToken", "type": "address" },
+            { "internalType": "address", "name": "_stakingManager", "type": "address" },
+            { "internalType": "uint256", "name": "_initialStakedAmount", "type": "uint256" },
+            { "internalType": "uint256", "name": "_duration", "type": "uint256" },
+            { "internalType": "uint256", "name": "_newRewardRatio", "type": "uint256" },
+            { "internalType": "address", "name": "_deployer", "type": "address" }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "target", "type": "address" }],
+        "name": "AddressEmptyCode",
+        "type": "error"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+        "name": "AddressInsufficientBalance",
+        "type": "error"
+    },
+    { "inputs": [], "name": "AlreadyAuthorized", "type": "error" },
+    { "inputs": [], "name": "CallerNotFactory", "type": "error" },
+    { "inputs": [], "name": "FailedInnerCall", "type": "error" },
+    {
+        "inputs": [{ "internalType": "address", "name": "_contract", "type": "address" }],
+        "name": "NoCode",
+        "type": "error"
+    },
+    { "inputs": [], "name": "NotAuthorized", "type": "error" },
+    { "inputs": [], "name": "NotFactoryDeployment", "type": "error" },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_x", "type": "uint256" },
+            { "internalType": "uint256", "name": "_y", "type": "uint256" }
+        ],
+        "name": "NotGreaterThan",
+        "type": "error"
+    },
+    { "inputs": [], "name": "NullAmount", "type": "error" },
+    { "inputs": [], "name": "RewardPool_DecreaseStakeNullAmount", "type": "error" },
+    { "inputs": [], "name": "RewardPool_IncreaseStakeNullAmount", "type": "error" },
+    { "inputs": [], "name": "RewardPool_InsufficientBalance", "type": "error" },
+    { "inputs": [], "name": "RewardPool_InvalidRewardAmount", "type": "error" },
+    { "inputs": [], "name": "RewardPool_InvalidRewardToken", "type": "error" },
+    { "inputs": [], "name": "RewardPool_NewPeriodWillFinishTooSoon", "type": "error" },
+    { "inputs": [], "name": "RewardPool_StakeNullAmount", "type": "error" },
+    { "inputs": [], "name": "RewardPool_WithdrawNullAmount", "type": "error" },
+    {
+        "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+        "name": "SafeERC20FailedOperation",
+        "type": "error"
+    },
+    { "inputs": [], "name": "Unauthorized", "type": "error" },
+    { "inputs": [], "name": "UnrecognizedCType", "type": "error" },
+    { "inputs": [], "name": "UnrecognizedParam", "type": "error" },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": false, "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "AddAuthorization",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "bytes32", "name": "_param", "type": "bytes32" },
+            { "indexed": true, "internalType": "bytes32", "name": "_cType", "type": "bytes32" },
+            { "indexed": false, "internalType": "bytes", "name": "_data", "type": "bytes" }
+        ],
+        "name": "ModifyParameters",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": false, "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "RemoveAuthorization",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_amount", "type": "uint256" }
+        ],
+        "name": "RewardPoolDecreaseStake",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_amount", "type": "uint256" }
+        ],
+        "name": "RewardPoolEmergencyWithdrawal",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_amount", "type": "uint256" }
+        ],
+        "name": "RewardPoolIncreaseStake",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": false, "internalType": "uint256", "name": "_reward", "type": "uint256" }],
+        "name": "RewardPoolRewardAdded",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_reward", "type": "uint256" }
+        ],
+        "name": "RewardPoolRewardPaid",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_amount", "type": "uint256" }
+        ],
+        "name": "RewardPoolStaked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_amount", "type": "uint256" }
+        ],
+        "name": "RewardPoolWithdrawn",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "RATIO_MULTIPLIER",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "_params",
+        "outputs": [
+            { "internalType": "address", "name": "stakingManager", "type": "address" },
+            { "internalType": "uint256", "name": "duration", "type": "uint256" },
+            { "internalType": "uint256", "name": "newRewardRatio", "type": "uint256" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "addAuthorization",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "authorizedAccounts",
+        "outputs": [{ "internalType": "bool", "name": "_authorized", "type": "bool" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "authorizedAccounts",
+        "outputs": [{ "internalType": "address[]", "name": "_accounts", "type": "address[]" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "cumulativeStakingManagerRewards",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "currentRewards",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_wad", "type": "uint256" }],
+        "name": "decreaseStake",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "earned",
+        "outputs": [{ "internalType": "uint256", "name": "_earned", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_rescueReceiver", "type": "address" },
+            { "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "emergencyWithdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "factory",
+        "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    { "inputs": [], "name": "getReward", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+        "inputs": [],
+        "name": "historicalRewards",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_wad", "type": "uint256" }],
+        "name": "increaseStake",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "lastTimeRewardApplicable",
+        "outputs": [{ "internalType": "uint256", "name": "_lastTime", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "lastUpdateTime",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "bytes32", "name": "_param", "type": "bytes32" },
+            { "internalType": "bytes", "name": "_data", "type": "bytes" }
+        ],
+        "name": "modifyParameters",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_reward", "type": "uint256" }],
+        "name": "notifyRewardAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "params",
+        "outputs": [
+            {
+                "components": [
+                    { "internalType": "address", "name": "stakingManager", "type": "address" },
+                    { "internalType": "uint256", "name": "duration", "type": "uint256" },
+                    { "internalType": "uint256", "name": "newRewardRatio", "type": "uint256" }
+                ],
+                "internalType": "struct IRewardPool.RewardPoolParams",
+                "name": "_rewardPoolParams",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "periodFinish",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_rewardsToQueue", "type": "uint256" }],
+        "name": "queueNewRewards",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "queuedRewards",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "removeAuthorization",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewardPerToken",
+        "outputs": [{ "internalType": "uint256", "name": "_rewardPerToken", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewardPerTokenPaid",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewardPerTokenStored",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewardRate",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewardToken",
+        "outputs": [{ "internalType": "contract IERC20", "name": "", "type": "address" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_totalStakedUpdated", "type": "uint256" }],
+        "name": "setTotalStaked",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_wad", "type": "uint256" }],
+        "name": "stake",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalStaked",
+        "outputs": [{ "internalType": "uint256", "name": "_totalStakedAmt", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    { "inputs": [], "name": "updateRewardHelper", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_wad", "type": "uint256" },
+            { "internalType": "bool", "name": "_claim", "type": "bool" }
+        ],
+        "name": "withdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/src/abis/StakingManager.json
+++ b/src/abis/StakingManager.json
@@ -1,0 +1,470 @@
+[
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_protocolToken", "type": "address" },
+            { "internalType": "address", "name": "_stakingToken", "type": "address" },
+            { "internalType": "uint256", "name": "_cooldownPeriod", "type": "uint256" }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "target", "type": "address" }],
+        "name": "AddressEmptyCode",
+        "type": "error"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+        "name": "AddressInsufficientBalance",
+        "type": "error"
+    },
+    { "inputs": [], "name": "AlreadyAuthorized", "type": "error" },
+    { "inputs": [], "name": "FailedInnerCall", "type": "error" },
+    {
+        "inputs": [{ "internalType": "address", "name": "_contract", "type": "address" }],
+        "name": "NoCode",
+        "type": "error"
+    },
+    { "inputs": [], "name": "NotAuthorized", "type": "error" },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_x", "type": "uint256" },
+            { "internalType": "uint256", "name": "_y", "type": "uint256" }
+        ],
+        "name": "NotGreaterThan",
+        "type": "error"
+    },
+    { "inputs": [], "name": "NullAmount", "type": "error" },
+    {
+        "inputs": [{ "internalType": "address", "name": "token", "type": "address" }],
+        "name": "SafeERC20FailedOperation",
+        "type": "error"
+    },
+    { "inputs": [], "name": "StakingManager_CooldownPeriodNotElapsed", "type": "error" },
+    { "inputs": [], "name": "StakingManager_ForwardingOnly", "type": "error" },
+    { "inputs": [], "name": "StakingManager_InvalidRewardType", "type": "error" },
+    { "inputs": [], "name": "StakingManager_NoPendingWithdrawal", "type": "error" },
+    { "inputs": [], "name": "StakingManager_NullRewardPool", "type": "error" },
+    { "inputs": [], "name": "StakingManager_NullRewardToken", "type": "error" },
+    { "inputs": [], "name": "StakingManager_StakeNullAmount", "type": "error" },
+    { "inputs": [], "name": "StakingManager_StakeNullReceiver", "type": "error" },
+    { "inputs": [], "name": "StakingManager_WithdrawAmountExceedsBalance", "type": "error" },
+    { "inputs": [], "name": "StakingManager_WithdrawNullAmount", "type": "error" },
+    { "inputs": [], "name": "Unauthorized", "type": "error" },
+    { "inputs": [], "name": "UnrecognizedCType", "type": "error" },
+    { "inputs": [], "name": "UnrecognizedParam", "type": "error" },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": false, "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "AddAuthorization",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "bytes32", "name": "_param", "type": "bytes32" },
+            { "indexed": true, "internalType": "bytes32", "name": "_cType", "type": "bytes32" },
+            { "indexed": false, "internalType": "bytes", "name": "_data", "type": "bytes" }
+        ],
+        "name": "ModifyParameters",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": false, "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "RemoveAuthorization",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": true, "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "StakingManagerActivateRewardType",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "uint256", "name": "_id", "type": "uint256" },
+            { "indexed": true, "internalType": "address", "name": "_rewardToken", "type": "address" },
+            { "indexed": true, "internalType": "address", "name": "_rewardPool", "type": "address" }
+        ],
+        "name": "StakingManagerAddRewardType",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [{ "indexed": true, "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "StakingManagerDeactivateRewardType",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": true, "internalType": "address", "name": "_rewardToken", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerEmergencyRewardWithdrawal",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerEmergencyWithdrawal",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": true, "internalType": "address", "name": "_rewardToken", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" },
+            { "indexed": true, "internalType": "address", "name": "_destination", "type": "address" }
+        ],
+        "name": "StakingManagerRewardPaid",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": true, "internalType": "uint256", "name": "_id", "type": "uint256" },
+            { "indexed": true, "internalType": "address", "name": "_rewardPool", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerRewardPoolStaked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerStaked",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerWithdrawalCancelled",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerWithdrawalInitiated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            { "indexed": true, "internalType": "address", "name": "_account", "type": "address" },
+            { "indexed": false, "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "StakingManagerWithdrawn",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "_params",
+        "outputs": [{ "internalType": "uint256", "name": "cooldownPeriod", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "_pendingWithdrawals",
+        "outputs": [
+            { "internalType": "uint256", "name": "amount", "type": "uint256" },
+            { "internalType": "uint256", "name": "timestamp", "type": "uint256" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "_rewardTypes",
+        "outputs": [
+            { "internalType": "address", "name": "rewardToken", "type": "address" },
+            { "internalType": "address", "name": "rewardPool", "type": "address" },
+            { "internalType": "bool", "name": "isActive", "type": "bool" },
+            { "internalType": "uint256", "name": "rewardIntegral", "type": "uint256" },
+            { "internalType": "uint256", "name": "rewardRemaining", "type": "uint256" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "activateRewardType",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "addAuthorization",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_rewardToken", "type": "address" },
+            { "internalType": "address", "name": "_rewardPool", "type": "address" }
+        ],
+        "name": "addRewardType",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "authorizedAccounts",
+        "outputs": [{ "internalType": "bool", "name": "_authorized", "type": "bool" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "authorizedAccounts",
+        "outputs": [{ "internalType": "address[]", "name": "_accounts", "type": "address[]" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    { "inputs": [], "name": "cancelWithdrawal", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+        "inputs": [{ "internalType": "address[2]", "name": "_accounts", "type": "address[2]" }],
+        "name": "checkpoint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_id", "type": "uint256" },
+            { "internalType": "address", "name": "_user", "type": "address" }
+        ],
+        "name": "claimableReward",
+        "outputs": [{ "internalType": "uint256", "name": "_claimableReward", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "deactivateRewardType",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "earned",
+        "outputs": [
+            {
+                "components": [
+                    { "internalType": "address", "name": "rewardToken", "type": "address" },
+                    { "internalType": "uint256", "name": "rewardAmount", "type": "uint256" }
+                ],
+                "internalType": "struct IStakingManager.EarnedData[]",
+                "name": "_claimable",
+                "type": "tuple[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_rescueReceiver", "type": "address" },
+            { "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "emergencyWithdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_id", "type": "uint256" },
+            { "internalType": "address", "name": "_rescueReceiver", "type": "address" },
+            { "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "emergencyWithdrawReward",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "getReward",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_account", "type": "address" },
+            { "internalType": "address", "name": "_forwardTo", "type": "address" }
+        ],
+        "name": "getRewardAndForward",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_wad", "type": "uint256" }],
+        "name": "initiateWithdrawal",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "bytes32", "name": "_param", "type": "bytes32" },
+            { "internalType": "bytes", "name": "_data", "type": "bytes" }
+        ],
+        "name": "modifyParameters",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "params",
+        "outputs": [
+            {
+                "components": [{ "internalType": "uint256", "name": "cooldownPeriod", "type": "uint256" }],
+                "internalType": "struct IStakingManager.StakingManagerParams",
+                "name": "_stakingManagerParams",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "pendingWithdrawals",
+        "outputs": [
+            {
+                "components": [
+                    { "internalType": "uint256", "name": "amount", "type": "uint256" },
+                    { "internalType": "uint256", "name": "timestamp", "type": "uint256" }
+                ],
+                "internalType": "struct IStakingManager.PendingWithdrawal",
+                "name": "_pendingWithdrawal",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "protocolToken",
+        "outputs": [{ "internalType": "contract IProtocolToken", "name": "", "type": "address" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "removeAuthorization",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "uint256", "name": "_id", "type": "uint256" },
+            { "internalType": "address", "name": "_user", "type": "address" }
+        ],
+        "name": "rewardIntegralFor",
+        "outputs": [{ "internalType": "uint256", "name": "_rewardIntegral", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "uint256", "name": "_id", "type": "uint256" }],
+        "name": "rewardTypes",
+        "outputs": [
+            {
+                "components": [
+                    { "internalType": "address", "name": "rewardToken", "type": "address" },
+                    { "internalType": "address", "name": "rewardPool", "type": "address" },
+                    { "internalType": "bool", "name": "isActive", "type": "bool" },
+                    { "internalType": "uint256", "name": "rewardIntegral", "type": "uint256" },
+                    { "internalType": "uint256", "name": "rewardRemaining", "type": "uint256" }
+                ],
+                "internalType": "struct IStakingManager.RewardTypeInfo",
+                "name": "_rewardTypeInfo",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "rewards",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            { "internalType": "address", "name": "_account", "type": "address" },
+            { "internalType": "uint256", "name": "_wad", "type": "uint256" }
+        ],
+        "name": "stake",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+        "name": "stakedBalances",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "stakingToken",
+        "outputs": [{ "internalType": "contract IStakingToken", "name": "", "type": "address" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalStaked",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "totalStakedRaw",
+        "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [{ "internalType": "address", "name": "_account", "type": "address" }],
+        "name": "userCheckpoint",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    { "inputs": [], "name": "withdraw", "outputs": [], "stateMutability": "nonpayable", "type": "function" }
+]

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -1,0 +1,115 @@
+import { type ReactNode } from 'react'
+import styled from 'styled-components'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import { ExternalLink } from 'react-feather'
+
+import { formatNumberWithStyle } from '~/utils'
+import { Table } from '~/components/Table'
+import { type SortableHeader } from '~/types'
+import { Grid, Text } from '~/styles'
+
+// Initialize dayjs relative time plugin
+dayjs.extend(relativeTime)
+
+export type ActivityItemProps = {
+    action: string
+    balanceChange: string
+    boostChange?: string
+    timestamp: number
+    txHash: string
+}
+
+type ActivityProps = {
+    activities?: ActivityItemProps[]
+    children?: ReactNode[]
+    fun?: boolean
+}
+
+const TxLink = styled.a`
+    color: ${({ theme }) => theme.colors.primary};
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: underline;
+    }
+`
+
+const TableHeader = styled(Grid)`
+    grid-template-columns: 1fr 1fr 1fr 1fr 80px;
+    align-items: center;
+    padding: 12px 24px;
+`
+
+export function Activity({ activities = [] }: ActivityProps) {
+    const headers: SortableHeader[] = [
+        {
+            label: 'Action',
+            tooltip: 'Shows the type of staking activity performed',
+        },
+        { label: 'Balance Change' },
+        { label: 'Boost Change' },
+        { label: 'Time' },
+        { label: 'Tx', unsortable: true },
+    ]
+
+    return (
+        <Table
+            container={TableHeader}
+            headerContainer={TableHeader}
+            headers={headers}
+            sorting={{ key: 'Time', dir: 'desc' }}
+            setSorting={() => {}}
+            rows={activities.map((activity, i) => (
+                <Table.Row
+                    key={i}
+                    container={TableHeader}
+                    headers={headers}
+                    items={[
+                        { content: <Text>{activity.action}</Text> },
+                        {
+                            content: (
+                                <Text>
+                                    {formatNumberWithStyle(parseFloat(activity.balanceChange), {
+                                        maxDecimals: 2,
+                                        minDecimals: 2,
+                                        style: 'currency',
+                                    })}
+                                </Text>
+                            ),
+                        },
+                        {
+                            content: (
+                                <Text>
+                                    {activity.boostChange
+                                        ? formatNumberWithStyle(parseFloat(activity.boostChange), {
+                                              maxDecimals: 2,
+                                              minDecimals: 2,
+                                              scalingFactor: 100,
+                                              style: 'percent',
+                                          })
+                                        : '-'}
+                                </Text>
+                            ),
+                        },
+                        { content: <Text>{dayjs(activity.timestamp).fromNow()}</Text> },
+                        {
+                            content: (
+                                <TxLink
+                                    href={`https://sepolia-optimism.etherscan.io/tx/${activity.txHash}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    <ExternalLink size={16} />
+                                </TxLink>
+                            ),
+                        },
+                    ]}
+                />
+            ))}
+        />
+    )
+}

--- a/src/components/AvailabilityBadge.tsx
+++ b/src/components/AvailabilityBadge.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+
+export const AvailabilityBadge = styled.span`
+    box-sizing: border-box;
+    background: #ffffff;
+    backdrop-filter: blur(50px);
+    border-radius: 23.5px;
+    padding: 8px 12px;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 11px;
+    line-height: 13px;
+    display: inline-flex;
+    align-items: center;
+    text-align: center;
+    color: #000000;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+`

--- a/src/components/IntentionHeader.tsx
+++ b/src/components/IntentionHeader.tsx
@@ -17,12 +17,14 @@ import { AuctionStats } from '~/containers/Auctions/Stats'
 import { useFlags } from 'flagsmith/react'
 
 import uniswapLogo from '~/assets/uniswap-icon.svg'
+import { StakeStats } from '~/containers/Stake/Stats'
 import { WrapperAd, WrapperAdProps } from './WrapperAd'
 
 enum Intention {
     AUCTION = 'auctions',
     BORROW = 'vaults',
     EARN = 'earn',
+    STAKE = 'stake',
 }
 
 const copy: Record<
@@ -48,6 +50,11 @@ const copy: Record<
         cta: 'Read more about earning opportunities →',
         ctaLink: `${LINK_TO_DOCS}detailed/intro/hai.html`,
     },
+    [Intention.STAKE]: {
+        subtitle: 'Stake KITE to earn protocol revenue and boost your incentives. ',
+        cta: 'Read more about staking →',
+        ctaLink: `${LINK_TO_DOCS}detailed/intro/hai.html`,
+    },
 }
 
 const typeOptions: BrandedSelectOption[] = [
@@ -58,18 +65,25 @@ const typeOptions: BrandedSelectOption[] = [
         description: 'Mint & borrow $HAI stablecoin against your preferred collateral',
     },
     {
+        label: 'Earn Rewards',
+        value: Intention.EARN,
+        icon: ['HAI', 'OP'],
+        description: 'Earn long term yields by staking a growing list of crypto assets',
+    },
+    {
+        label: 'STAKE $KITE',
+        value: Intention.STAKE,
+        icon: ['KITE'],
+        description: 'Stake KITE to earn revenue share and boost your HAI minting incentives.',
+    },
+    {
         label: 'Buy $HAI',
         value: '',
         icon: <img src={uniswapLogo} alt="" />,
         description: 'Market buy $HAI from various pairs on Uniswap',
-        href: 'https://app.uniswap.org/swap',
+        href: 'https://swap.defillama.com/?chain=optimism&from=&to=0x10398abc267496e49106b07dd6be13364d10dc71',
     },
-    {
-        label: 'Earn Rewards',
-        value: Intention.EARN,
-        icon: ['OP', 'KITE'],
-        description: 'Earn long term yields by staking a growing list of crypto assets',
-    },
+
     {
         label: 'Buy Auctioned Assets',
         value: Intention.AUCTION,
@@ -84,7 +98,7 @@ const wrappers: WrapperAdProps[] = [
         status: 'NOW LIVE',
         description: 'Convert your VELO into haiVELO to use as collateral while earning veVELO rewards.',
         cta: 'Mint haiVELO',
-        ctaLink: '/earn',
+        ctaLink: '',
         tokenImages: ['HAIVELO'],
     },
 ]
@@ -112,6 +126,12 @@ export function IntentionHeader({ children }: IntentionHeaderProps) {
             return {
                 type: Intention.EARN,
                 stats: <EarnStats />,
+            }
+        }
+        if (location.pathname.startsWith('/stake')) {
+            return {
+                type: Intention.STAKE,
+                stats: <StakeStats />,
             }
         }
         if (location.pathname.startsWith('/vaults')) {

--- a/src/components/Modal/StakingClaimModal.tsx
+++ b/src/components/Modal/StakingClaimModal.tsx
@@ -1,0 +1,344 @@
+import { useStoreActions, useStoreState } from '~/store'
+import { Modal } from '.'
+import { CenteredFlex, Flex, HaiButton, Text } from '~/styles'
+import { ActionState, formatNumberWithStyle, tokenMap } from '~/utils'
+import styled from 'styled-components'
+import { ContentWithStatus } from '../ContentWithStatus'
+import { tokenAssets } from '~/utils'
+import { handleTransactionError, useEthersSigner } from '~/hooks'
+// import { useAccount } from 'wagmi'
+import { useState } from 'react'
+import { TokenArray } from '../TokenArray'
+// import dayjs from 'dayjs'
+import { useStakingData } from '~/hooks/useStakingData'
+import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { ethers } from 'ethers'
+
+export function StakingClaimModal() {
+    const signer = useEthersSigner()
+    const {
+        vaultModel: { liquidationData },
+        popupsModel: { isStakeClaimPopupOpen },
+    } = useStoreState((state) => state)
+    const {
+        popupsModel: { setIsStakeClaimPopupOpen, setIsWaitingModalOpen, setWaitingPayload },
+        stakingModel: stakingActions,
+    } = useStoreActions((actions) => actions)
+
+    const { userRewards, refetchAll } = useStakingData()
+
+    const [claiming, setClaiming] = useState(false)
+
+    const { prices: veloPrices } = useVelodromePrices()
+
+    const haiPrice = parseFloat(liquidationData?.currentRedemptionPrice || '1')
+    const kitePrice = veloPrices?.KITE.raw
+    const opPrice = liquidationData?.collateralLiquidationData?.OP?.currentPrice.value
+
+    const HAI_ADDRESS = import.meta.env.VITE_HAI_ADDRESS
+    const KITE_ADDRESS = import.meta.env.VITE_KITE_ADDRESS
+    const OP_ADDRESS = import.meta.env.VITE_OP_ADDRESS
+
+    const rewardsDataMap = {
+        [HAI_ADDRESS]: {
+            id: 0,
+            name: tokenAssets.HAI.symbol,
+            tokenImg: tokenAssets.HAI.icon,
+            price: haiPrice,
+        },
+        [KITE_ADDRESS]: {
+            id: 1,
+            name: tokenAssets.KITE.symbol,
+            tokenImg: tokenAssets.KITE.icon,
+            price: kitePrice,
+        },
+        [OP_ADDRESS]: {
+            id: 2,
+            name: tokenAssets.OP.symbol,
+            tokenImg: tokenAssets.OP.icon,
+            price: opPrice,
+        },
+    }
+
+    const onClaim = async () => {
+        if (!signer || claiming) return
+        try {
+            setClaiming(true)
+
+            setIsWaitingModalOpen(true)
+            setWaitingPayload({
+                title: 'Waiting For Confirmation',
+                text: 'Claim Rewards',
+                hint: 'Confirm this transaction in your wallet',
+                status: ActionState.LOADING,
+            })
+
+            stakingActions.setTransactionState(ActionState.LOADING)
+            await stakingActions.getReward({ signer })
+
+            stakingActions.setTransactionState(ActionState.SUCCESS)
+            setIsWaitingModalOpen(false)
+            setWaitingPayload({ status: ActionState.NONE })
+
+            // Refetch all data after successful claim
+            await refetchAll({})
+
+            setIsStakeClaimPopupOpen(false)
+        } catch (error) {
+            console.error('Failed to claim rewards:', error)
+            stakingActions.setTransactionState(ActionState.ERROR)
+            handleTransactionError(error)
+        } finally {
+            setClaiming(false)
+        }
+    }
+
+    if (!isStakeClaimPopupOpen) return null
+    const content = userRewards.map((reward) => {
+        return (
+            <ClaimableAsset
+                key={`reward-${reward.id}`}
+                asset={rewardsDataMap[reward.tokenAddress as any].name}
+                amount={ethers.utils.formatEther(reward.amount)}
+                price={rewardsDataMap[reward.tokenAddress as any].price as number}
+                claim={{
+                    description: `${rewardsDataMap[reward.tokenAddress as any].name} Rewards`,
+                    createdAt: Date.now(),
+                }}
+            />
+        )
+    })
+
+    return (
+        <Modal
+            heading="CLAIM"
+            maxWidth="560px"
+            onClose={() => setIsStakeClaimPopupOpen(false)}
+            footerContent={
+                <Flex $width="100%" $justify="space-between" $align="center">
+                    <Text>
+                        <strong>Total Estimated Value:</strong>
+                        &nbsp;
+                        {formatNumberWithStyle(
+                            userRewards.reduce((acc, reward) => {
+                                const amount = parseFloat(ethers.utils.formatEther(reward.amount))
+                                const price = rewardsDataMap[reward.tokenAddress as any].price as number
+                                return acc + amount * price
+                            }, 0),
+                            { style: 'currency' }
+                        )}
+                    </Text>
+                    <HaiButton $variant="yellowish" onClick={onClaim} disabled={claiming || !userRewards.length}>
+                        {claiming ? 'Claiming...' : 'Claim All'}
+                    </HaiButton>
+                </Flex>
+            }
+        >
+            <Text>Claim your staking rewards. Unclaimed rewards will accrue below and do not expire.</Text>
+            <ScrollableBody>
+                <ContentWithStatus
+                    loading={false}
+                    error={undefined}
+                    isEmpty={!content.filter((c) => !!c).length}
+                    emptyContent="No rewards available to claim"
+                >
+                    {content}
+                </ContentWithStatus>
+            </ScrollableBody>
+        </Modal>
+    )
+}
+
+type Claim = {
+    description: string
+    createdAt: number
+}
+
+type ClaimableAssetProps = {
+    asset: string
+    amount: string
+    price?: number
+    claim?: Claim
+    distributor?: any
+    onSuccess?: () => void
+} /*& (
+    | {
+          asset: string
+          auction: IAuction
+          internal?: undefined
+          incentive: boolean
+      }
+    | {
+          asset: 'COIN' | 'PROTOCOL_TOKEN'
+          auction?: undefined
+          internal: boolean
+          incentive: boolean
+      }
+)*/
+
+// const returnDaysLeftToClaim = (date: number) => {
+//     const deploymentTime = dayjs(date * 1000)
+//     const dayDiff = dayjs().diff(deploymentTime, 'day')
+//     if (dayDiff > 90) {
+//         return 0
+//     }
+//     return 90 - dayjs().diff(deploymentTime, 'day')
+// }
+
+const ClaimableAssetContainer = styled(Flex).attrs((props) => ({
+    $width: '100%',
+    $justify: 'space-between',
+    $align: 'center',
+    $gap: 12,
+    ...props,
+}))`
+    padding: 8px 16px;
+    border-radius: 20px;
+    border: 2px solid rgba(0, 0, 0, 0.1);
+`
+
+function ClaimableAsset({ asset, amount, price = 0, claim }: ClaimableAssetProps) {
+    // const signer = useEthersSigner()
+    // const { address: account } = useAccount()
+
+    // const {
+    //     auctionModel: auctionActions,
+    //     popupsModel: popupsActions,
+    //     transactionsModel: transactionsActions,
+    // } = useStoreActions((actions) => actions)
+
+    const [status] = useState(ActionState.NONE)
+
+    // const onClaim = async () => {
+    /*if (incentive) {
+            const formatted = isFormattedAddress(account)
+            if (!formatted) {
+                console.debug('wrong address')
+                return false
+            }
+            const { index, amount, proof } = claim
+            try {
+                const txResponse = await distributor.claim(index, formatted, amount, proof)
+                if (txResponse) {
+                    transactionsActions.addTransaction({
+                        chainId: txResponse?.chainId,
+                        hash: txResponse?.hash,
+                        from: txResponse.from,
+                        summary: `Claiming ${asset}`,
+                        addedTime: new Date().getTime(),
+                        originalTx: txResponse,
+                    })
+                    popupsActions.setIsWaitingModalOpen(true)
+                    popupsActions.setWaitingPayload({
+                        title: 'Transaction Submitted',
+                        hash: txResponse?.hash,
+                        status: 'success',
+                    })
+                    await txResponse.wait()
+                    onSuccess?.()
+                    popupsActions.setIsWaitingModalOpen(false)
+                    popupsActions.setWaitingPayload({ status: ActionState.NONE })
+                } else {
+                    throw new Error('No transaction request!')
+                }
+            } catch (e) {
+                console.error(e)
+            }
+        } else {
+            if (status === ActionState.LOADING || !signer) return
+
+            setStatus(ActionState.LOADING)
+            popupsActions.setIsWaitingModalOpen(true)
+            popupsActions.setWaitingPayload({
+                status: ActionState.LOADING,
+                title: 'Claiming Assets',
+            })
+            try {
+                if (internal) {
+                    await auctionActions.auctionClaimInternalBalance({
+                        signer,
+                        auctionId: '1',
+                        auctionType: 'COLLATERAL',
+                        bid: amount,
+                        token: asset,
+                        title: `Claim ${tokenMap[asset]}`,
+                    })
+                } else if (auction) {
+                    await auctionActions.auctionClaim({
+                        signer,
+                        auctionId: auction.auctionId,
+                        title: 'Claim Assets',
+                        auctionType: auction.englishAuctionType,
+                        bid: amount,
+                    })
+                }
+                setStatus(ActionState.SUCCESS)
+                popupsActions.setWaitingPayload({
+                    status: ActionState.SUCCESS,
+                    title: 'Claiming Assets',
+                })
+                onSuccess?.()
+                await wait(3000)
+                popupsActions.setIsWaitingModalOpen(false)
+                popupsActions.setWaitingPayload({ status: ActionState.NONE })
+            } catch (e: any) {
+                handleTransactionError(e)
+                setStatus(ActionState.ERROR)
+                popupsActions.setWaitingPayload({
+                    status: ActionState.ERROR,
+                    title: 'Claiming Assets',
+                    hint: 'An error occurred',
+                })
+            }
+        }*/
+    // }
+
+    if (!claim) return <div></div>
+
+    return (
+        <ClaimableAssetContainer style={status === ActionState.SUCCESS ? { opacity: 0.5 } : undefined}>
+            <CenteredFlex $gap={12}>
+                <TokenArray size={48} tokens={[(tokenMap[asset] || asset) as any]} hideLabel />
+                <Flex $width="100%" $column $justify="center" $align="flex-start" $gap={4}>
+                    <>
+                        <Text $fontSize="1em" $fontWeight={700}>
+                            {claim.description}
+                        </Text>
+                    </>
+
+                    <Text $fontSize="1em" $fontWeight={700}>
+                        {formatNumberWithStyle(amount, { maxDecimals: 4 })} {tokenMap[asset] || asset}
+                    </Text>
+                    <Text $fontSize="0.7em">
+                        {formatNumberWithStyle(parseFloat(amount) * price, {
+                            style: 'currency',
+                            minDecimals: 2,
+                            maxDecimals: 2,
+                        })}
+                    </Text>
+                </Flex>
+            </CenteredFlex>
+            <CenteredFlex $column $gap={12}></CenteredFlex>
+        </ClaimableAssetContainer>
+    )
+}
+
+const ScrollableBody = styled(Flex).attrs((props) => ({
+    $width: 'calc(100% + 72px)',
+    $column: true,
+    $justify: 'flex-start',
+    $align: 'stretch',
+    $gap: 12,
+    ...props,
+}))`
+    max-height: max(calc(100vh - 400px), 100px);
+    padding: 12px 36px;
+    overflow: hidden auto;
+    border-top: 1px solid rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+
+    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+        width: calc(100% + 32px);
+        padding: 12px 16px;
+    `}
+`

--- a/src/components/Modal/StakingTxModal/Approvals.tsx
+++ b/src/components/Modal/StakingTxModal/Approvals.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo } from 'react'
+import { ActionState } from '~/utils'
+// import { useStoreState } from '~/store'
+import { ApprovalState, useTokenApproval } from '~/hooks'
+
+import styled from 'styled-components'
+import { CenteredFlex, HaiButton, Text } from '~/styles'
+import { ModalBody, ModalFooter } from '../index'
+import { ArrowUpCircle, CheckCircle } from 'react-feather'
+import { Loader } from '~/components/Loader'
+
+type ApprovalsProps = {
+    onNext: () => void
+    isStaking: boolean
+    amount: string
+}
+
+export function Approvals({ onNext, isStaking, amount }: ApprovalsProps) {
+    // const {
+    //     connectWalletModel: { proxyAddress },
+    // } = useStoreState((state) => state)
+
+    const [kiteApproval, approveKite] = useTokenApproval(
+        amount,
+        isStaking ? import.meta.env.VITE_KITE_ADDRESS : import.meta.env.VITE_STAKING_TOKEN_ADDRESS,
+        import.meta.env.VITE_STAKING_MANAGER,
+        '18',
+        true
+    )
+
+    // debugger
+
+    const { isApproved, button } = useMemo(() => {
+        if (!isStaking && !amount) {
+            return { isApproved: true, button: null }
+        }
+
+        switch (kiteApproval) {
+            case ApprovalState.NOT_APPROVED:
+            case ApprovalState.PENDING:
+            case ApprovalState.UNKNOWN:
+                return {
+                    isApproved: false,
+                    button: (
+                        <HaiButton
+                            $variant="yellowish"
+                            $width="100%"
+                            $justify="center"
+                            disabled={kiteApproval === ApprovalState.PENDING}
+                            onClick={approveKite}
+                        >
+                            {kiteApproval === ApprovalState.PENDING
+                                ? 'Pending Approval..'
+                                : `Approve ${isStaking ? 'KITE' : 'stKITE'}`}
+                        </HaiButton>
+                    ),
+                }
+            case ApprovalState.APPROVED:
+            default:
+                return {
+                    isApproved: true,
+                    button: null,
+                }
+        }
+    }, [kiteApproval, approveKite, isStaking, amount])
+
+    useEffect(() => {
+        if (isApproved) onNext()
+    }, [isApproved, onNext])
+
+    const statusIcon = useMemo(() => {
+        if (kiteApproval === ApprovalState.APPROVED) {
+            return <CheckCircle width="40px" className={ActionState.SUCCESS} />
+        }
+        if (kiteApproval === ApprovalState.PENDING) {
+            return <Loader size={40} />
+        }
+        return <ArrowUpCircle width={'40px'} className={'stateless'} />
+    }, [kiteApproval])
+
+    return (
+        <>
+            <ModalBody>
+                <ImageContainer>{statusIcon}</ImageContainer>
+                <Text $fontWeight={700}>Token Approvals</Text>
+                <Text>Allow Staking Manager to manage your {isStaking ? 'KITE' : 'stKITE'} tokens</Text>
+            </ModalBody>
+            <ModalFooter $gap={24}>{button}</ModalFooter>
+        </>
+    )
+}
+
+const ImageContainer = styled(CenteredFlex).attrs((props) => ({
+    $width: '100%',
+    ...props,
+}))`
+    svg {
+        margin-top: 12px;
+        height: 40px;
+        stroke: ${({ theme }) => theme.colors.blueish};
+        path {
+            stroke-width: 1 !important;
+        }
+        &.${ActionState.NONE} {
+            stroke: black;
+        }
+        &.${ActionState.SUCCESS} {
+            stroke: ${({ theme }) => theme.colors.successColor};
+        }
+        &.${ActionState.ERROR} {
+            stroke: ${({ theme }) => theme.colors.dangerColor};
+        }
+    }
+`

--- a/src/components/Modal/StakingTxModal/Confirm.tsx
+++ b/src/components/Modal/StakingTxModal/Confirm.tsx
@@ -1,0 +1,184 @@
+import { useRef } from 'react'
+import { ActionState, formatNumberWithStyle, formatTimeFromSeconds } from '~/utils'
+import { useStoreActions, useStoreState } from '~/store'
+import { handleTransactionError, useEthersSigner } from '~/hooks'
+import { useStaking } from '~/providers/StakingProvider'
+// import { useStakingSummary } from '~/hooks/useStakingSummary'
+
+import styled from 'styled-components'
+import { HaiButton, Text } from '~/styles'
+import { TransactionSummary } from '~/components/TransactionSummary'
+import { ModalBody, ModalFooter } from '../index'
+// import { stakingModel } from '~/model/stakingModel'
+import { useBoost } from '~/hooks/useBoost'
+
+type ConfirmProps = {
+    onClose?: () => void
+    isStaking: boolean
+    amount: string
+    stakedAmount: string
+    isWithdraw?: boolean
+    onSuccess?: () => void
+}
+
+export function Confirm({ onClose, isStaking, amount, isWithdraw, onSuccess }: ConfirmProps) {
+    const signer = useEthersSigner()
+    const { popupsModel: popupsActions, stakingModel: stakingActions } = useStoreActions((actions) => actions)
+    const { stakingModel: stakingStates } = useStoreState((state) => state)
+    const { refetchAll } = useStaking()
+    // Use the effective staked amount from useStakingSummary
+    // const { myStaked } = useStakingSummary()
+
+    const { simulateNetBoost } = useBoost()
+
+    // Use ref to prevent reopening modal after completion
+    const hasCompletedRef = useRef(false)
+
+    const handleConfirm = async () => {
+        if (!signer) return
+
+        popupsActions.setIsWaitingModalOpen(true)
+        popupsActions.setWaitingPayload({
+            title: 'Waiting For Confirmation',
+            text: isStaking ? 'Stake KITE' : isWithdraw ? 'Withdraw KITE' : 'Unstake KITE',
+            hint: 'Confirm this transaction in your wallet',
+            status: ActionState.LOADING,
+        })
+
+        try {
+            stakingActions.setTransactionState(ActionState.LOADING)
+
+            console.log('setTransactionState')
+
+            if (isStaking) {
+                await stakingActions.stake({
+                    signer,
+                    amount,
+                })
+            } else if (isWithdraw) {
+                await stakingActions.withdraw({
+                    signer,
+                })
+            } else {
+                await stakingActions.unstake({
+                    signer,
+                    amount,
+                })
+            }
+
+            stakingActions.setTransactionState(ActionState.SUCCESS)
+            popupsActions.setIsWaitingModalOpen(false)
+            popupsActions.setWaitingPayload({ status: ActionState.NONE })
+
+            // Mark as completed to prevent reopening
+            hasCompletedRef.current = true
+
+            // First close the modal to prevent any race conditions
+            onClose?.()
+
+            // Simplified refetch since optimistic updates are handled in the model
+            await refetchAll({})
+
+            // Call onSuccess if provided
+            onSuccess?.()
+        } catch (e: any) {
+            stakingActions.setTransactionState(ActionState.ERROR)
+            handleTransactionError(e)
+        }
+    }
+
+    // Use effective amount from useStakingSummary
+    const effectiveStakedAmount = stakingStates.stakedBalance
+
+    const totalStaked = Number(stakingStates.totalStaked) > 0 ? Number(stakingStates.totalStaked) / 10 ** 18 : 0
+
+    return (
+        <>
+            <ModalBody>
+                <Description>
+                    Stake KITE for a boosted HAI and revenue share. stKITE can be claimed 21 days after unstaking.
+                    Additional unstaking requests are combined with the previous request and the cooldown period is
+                    reset.
+                </Description>
+                <TransactionSummary
+                    items={[
+                        {
+                            label: 'Amount',
+                            value: {
+                                current: `${formatNumberWithStyle(
+                                    isWithdraw
+                                        ? (Number(effectiveStakedAmount) + Number(amount)).toString()
+                                        : effectiveStakedAmount.toString(),
+                                    {
+                                        maxDecimals: 2,
+                                        minDecimals: 0,
+                                    }
+                                )} `,
+                                after: `${formatNumberWithStyle(
+                                    isStaking
+                                        ? (Number(effectiveStakedAmount) + Number(amount)).toString()
+                                        : isWithdraw
+                                        ? effectiveStakedAmount
+                                        : (Number(effectiveStakedAmount) - Number(amount)).toString(),
+                                    {
+                                        maxDecimals: 2,
+                                        minDecimals: 0,
+                                    }
+                                )}`,
+                                label: 'stKITE',
+                            },
+                        },
+                        {
+                            label: 'Net Boost',
+                            value: {
+                                current: `${
+                                    !isWithdraw
+                                        ? `${formatNumberWithStyle(
+                                              simulateNetBoost(Number(effectiveStakedAmount), Number(totalStaked)),
+                                              {
+                                                  maxDecimals: 2,
+                                                  minDecimals: 0,
+                                              }
+                                          )}x`
+                                        : ''
+                                }`,
+                                after: `${
+                                    !isWithdraw
+                                        ? `${formatNumberWithStyle(
+                                              simulateNetBoost(
+                                                  Number(effectiveStakedAmount) + (isStaking ? 1 : -1) * Number(amount),
+                                                  Number(totalStaked + (isStaking ? 1 : -1) * Number(amount))
+                                              ),
+                                              {
+                                                  maxDecimals: 2,
+                                                  minDecimals: 0,
+                                              }
+                                          )}x`
+                                        : ''
+                                }`,
+                                label: '',
+                            },
+                        },
+                    ]}
+                />
+                {!isStaking && (
+                    <Text $fontSize="0.8em" $color="rgba(0,0,0,0.4)">
+                        Note: Unstaked KITE has a {formatTimeFromSeconds(Number(stakingStates.cooldownPeriod))} cooldown
+                        period before it can be claimed
+                    </Text>
+                )}
+            </ModalBody>
+            <ModalFooter $justify="flex-end">
+                <HaiButton $variant="yellowish" onClick={handleConfirm}>
+                    Confirm Transaction
+                </HaiButton>
+            </ModalFooter>
+        </>
+    )
+}
+
+const Description = styled(Text)`
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+        font-size: ${theme.font.small};
+    `}
+`

--- a/src/components/Modal/StakingTxModal/index.tsx
+++ b/src/components/Modal/StakingTxModal/index.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState, useRef } from 'react'
+
+import { Approvals } from './Approvals'
+import { Confirm } from './Confirm'
+import { Modal, type ModalProps } from '../index'
+import { BrandedTitle } from '~/components/BrandedTitle'
+import { X } from '~/components/Icons/X'
+
+enum StakingTxStep {
+    APPROVE,
+    CONFIRM,
+}
+
+type StakingTxModalProps = ModalProps & {
+    isStaking: boolean
+    amount: string
+    stakedAmount: string
+    isWithdraw?: boolean
+    onSuccess?: () => void
+}
+
+export function StakingTxModal({
+    isStaking,
+    amount,
+    stakedAmount,
+    isWithdraw = false,
+    onSuccess,
+    ...props
+}: StakingTxModalProps) {
+    const [step, setStep] = useState(StakingTxStep.APPROVE)
+    // Track if transaction is completed to prevent reopening
+    const hasClosedRef = useRef(false)
+
+    // Ensure we only close once
+    const handleClose = () => {
+        if (hasClosedRef.current) return
+        hasClosedRef.current = true
+
+        if (props.onClose) {
+            props.onClose()
+        }
+    }
+
+    const content = useMemo(() => {
+        if (isWithdraw)
+            return (
+                <Confirm
+                    onClose={handleClose}
+                    isStaking={isStaking}
+                    amount={amount}
+                    stakedAmount={stakedAmount}
+                    isWithdraw={isWithdraw}
+                    onSuccess={onSuccess}
+                />
+            )
+        switch (step) {
+            case StakingTxStep.APPROVE:
+                return <Approvals onNext={() => setStep(StakingTxStep.CONFIRM)} isStaking={isStaking} amount={amount} />
+            case StakingTxStep.CONFIRM:
+                return (
+                    <Confirm
+                        onClose={handleClose}
+                        isStaking={isStaking}
+                        amount={amount}
+                        stakedAmount={stakedAmount}
+                        isWithdraw={isWithdraw}
+                        onSuccess={onSuccess}
+                    />
+                )
+        }
+    }, [step, handleClose, isStaking, amount, stakedAmount, isWithdraw, onSuccess])
+
+    return (
+        <Modal
+            onClose={handleClose}
+            {...props}
+            maxWidth={step === StakingTxStep.APPROVE ? '500px' : '500px'}
+            overrideContent={
+                <>
+                    <Modal.Header>
+                        <BrandedTitle textContent="MANAGE STAKING" $fontSize="2.5em" />
+                        {props.onClose && (
+                            <Modal.Close onClick={handleClose}>
+                                <X size={14} />
+                            </Modal.Close>
+                        )}
+                    </Modal.Header>
+                    {content}
+                </>
+            }
+        />
+    )
+}

--- a/src/components/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator.tsx
@@ -17,6 +17,8 @@ export type ProgressIndicatorProps = {
     labels?: Progress[]
 }
 export function ProgressIndicator({ progress, simulatedProgress, colorLimits, labels }: ProgressIndicatorProps) {
+    // const data = progressToPercentage(progress.progress)
+    // const item = colorLimits.map(progressToPercentage)
     return (
         <Container>
             <Inner $limits={colorLimits.map(progressToPercentage) as any} />

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -13,6 +13,7 @@ export type StatProps = {
     tooltip?: ReactChildren
     button?: ReactChildren
     fullWidth?: boolean
+    badge?: string
 }
 
 type StatsProps = FlexProps & {
@@ -39,13 +40,16 @@ type StatElProps = FlexProps & {
     unbordered?: boolean
 }
 export function Stat({ stat, unbordered, ...props }: StatElProps) {
-    const { header, headerStatus, label, tooltip, button, fullWidth } = stat
+    const { header, headerStatus, label, tooltip, button, fullWidth, badge } = stat
 
     return (
         <StatContainer $unbordered={unbordered} $fullWidth={fullWidth || !!button} {...props}>
             <Flex $width="100%" $column $justify="flex-end" $align="flex-start" $gap={12} $fontSize="0.7rem">
                 <Flex $width="100%" $justify="flex-start" $align="center" $gap={12}>
-                    {typeof header === 'string' ? <StatHeader>{header}</StatHeader> : header}
+                    <BadgeWrapper>
+                        {typeof header === 'string' ? <StatHeader>{header}</StatHeader> : header}
+                        {badge && <Badge>{badge}</Badge>}
+                    </BadgeWrapper>
                     {headerStatus}
                 </Flex>
                 <Flex $justify="flex-start" $align="center" $gap={8}>
@@ -144,5 +148,32 @@ const StatHeader = styled(Text).attrs((props) => ({
     $fontWeight: 700,
     ...props,
 }))``
+
+const BadgeWrapper = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`
+
+const Badge = styled.div`
+    margin-left: 8px;
+    width: 38.84px;
+    height: 18.77px;
+    background: #ffffff;
+    backdrop-filter: blur(50px);
+    border-radius: 23.5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-style: normal;
+    font-weight: 700;
+    font-size: 7px;
+    line-height: 8px;
+    text-align: center;
+    color: #00ac11;
+    box-sizing: border-box;
+`
 
 Stat.Header = StatHeader

--- a/src/components/WrapperAd.tsx
+++ b/src/components/WrapperAd.tsx
@@ -29,6 +29,7 @@ export function WrapperAd({
     status = 'NOW LIVE',
     description,
     cta = 'Get HAI to Earn',
+    ctaLink,
     tokenImages,
     bgVariant = 0,
 }: WrapperAdProps) {
@@ -65,7 +66,17 @@ export function WrapperAd({
                 </Header>
                 <Text $fontSize="0.8rem">{description}</Text>
             </Flex>
-            <HaiButton $variant="yellowish" $gap={8} onClick={handleBannerClick}>
+            <HaiButton
+                $variant="yellowish"
+                $gap={8}
+                onClick={() => {
+                    if (ctaLink) {
+                        window.open(ctaLink, '_blank')
+                    } else {
+                        handleBannerClick()
+                    }
+                }}
+            >
                 <Text>{cta}</Text>
             </HaiButton>
             {accountModalActive && !wrapTokenActive && (

--- a/src/containers/Earn/Stats.tsx
+++ b/src/containers/Earn/Stats.tsx
@@ -10,14 +10,39 @@ import { RewardsTokenArray } from '~/components/TokenArray'
 import { Stats, type StatProps } from '~/components/Stats'
 import { Loader } from '~/components/Loader'
 import { RefreshCw } from 'react-feather'
+import { useBoost } from '~/hooks/useBoost'
+import styled from 'styled-components'
+
+const StyledRewardsAPYContainer = styled.div`
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+`
+
+const StyledRewardsAPY = styled.div`
+    font-size: 2.2em;
+    font-weight: 700;
+    text-decoration: line-through;
+`
+
+const StyledRewardsAPYWithBoost = styled.div`
+    color: #00ac11;
+    font-size: 2.2em;
+    font-weight: 700;
+    margin-left: 8px;
+`
 
 export function EarnStats() {
     const { address } = useAccount()
 
-    const { rows } = useEarnStrategies()
+    const { rows, averageAPR } = useEarnStrategies()
     const { popupsModel: popupsActions } = useStoreActions((actions) => actions)
 
-    const { value, apy } = useMemo(() => {
+    const { netBoostValue } = useBoost()
+
+    //console.log('baseAPR', netBoostValue, baseAPR)
+
+    const { value } = useMemo(() => {
         return rows.reduce(
             (obj, { userPosition = '0', apy }) => {
                 const apyToUse = apy ? apy : 0
@@ -28,6 +53,53 @@ export function EarnStats() {
             { value: 0, apy: 0 }
         )
     }, [rows])
+
+    const formattedWeightedAPR = useMemo(() => {
+        return formatNumberWithStyle(averageAPR && averageAPR.averageWeightedAPR ? averageAPR.averageWeightedAPR : 0, {
+            maxDecimals: 2,
+            scalingFactor: 1,
+            suffixed: true,
+            style: 'percent',
+        })
+    }, [averageAPR])
+
+    const formattedBoostedAPR = useMemo(() => {
+        return formatNumberWithStyle(
+            averageAPR && averageAPR.averageWeightedBoostedAPR ? averageAPR.averageWeightedBoostedAPR : 0,
+            {
+                maxDecimals: 2,
+                scalingFactor: 1,
+                suffixed: true,
+                style: 'percent',
+            }
+        )
+    }, [averageAPR])
+
+    const formattedZeroAPR = useMemo(() => {
+        return formatNumberWithStyle(0, {
+            maxDecimals: 2,
+            scalingFactor: 100,
+            suffixed: true,
+            style: 'percent',
+        })
+    }, [])
+
+    const formattedAPR = useMemo(() => {
+        if (averageAPR && averageAPR.averageWeightedBoostedAPR && averageAPR.averageWeightedAPR) {
+            if (formattedWeightedAPR !== formattedBoostedAPR) {
+                return (
+                    <StyledRewardsAPYContainer>
+                        <StyledRewardsAPY> {formattedWeightedAPR} </StyledRewardsAPY>
+                        <StyledRewardsAPYWithBoost>{formattedBoostedAPR}</StyledRewardsAPYWithBoost>
+                    </StyledRewardsAPYContainer>
+                )
+            } else {
+                return formattedWeightedAPR
+            }
+        } else {
+            return formattedZeroAPR
+        }
+    }, [averageAPR, formattedWeightedAPR, formattedBoostedAPR, formattedZeroAPR])
 
     const dummyStats: StatProps[] = [
         {
@@ -40,21 +112,27 @@ export function EarnStats() {
             tooltip: 'Total eligible value participating in DAO rewards campaign activities',
         },
         {
-            header: formatNumberWithStyle(value ? apy / value : 0, {
-                maxDecimals: 1,
-                scalingFactor: 100,
-                suffixed: true,
-                style: 'percent',
-            }),
-            label: 'My Est. Rewards APY',
+            header: isNaN(netBoostValue)
+                ? '...'
+                : `${formatNumberWithStyle(netBoostValue, {
+                      minDecimals: 0,
+                      maxDecimals: 2,
+                  })}x`,
+            label: 'My Net HAI Boost',
+            badge: 'BOOST',
+            tooltip: 'Your current boost multiplier based on your staked KITE.',
+        },
+        {
+            header: formattedAPR,
+            label: 'My Rewards APR',
             tooltip:
-                'Current estimated APY of campaign rewards based on current value participating and value of rewards tokens',
+                'Current estimated APR of campaign rewards based on current value participating and value of rewards tokens',
         },
         {
             // header: '$0',
             header: <Loader speed={0.5} icon={<RefreshCw />} />,
             headerStatus: <RewardsTokenArray tokens={['OP', 'KITE']} hideLabel />,
-            label: 'My Campaign Rewards',
+            label: 'My Rewards',
             tooltip: 'Rewards currently voted upon and distributed by DAO approximately once per month.',
             button: (
                 <HaiButton $variant="yellowish" onClick={() => popupsActions.setIsClaimPopupOpen(true)}>

--- a/src/containers/Earn/StrategyTable.tsx
+++ b/src/containers/Earn/StrategyTable.tsx
@@ -39,6 +39,52 @@ type StrategyTableProps = {
 //     `}
 // `
 
+const BadgeWrapper = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`
+
+const Badge = styled.div`
+    margin-left: 0px;
+    width: 38.84px;
+    height: 18.77px;
+    background: #ffffff;
+    backdrop-filter: blur(50px);
+    border-radius: 23.5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-style: normal;
+    font-weight: 700;
+    font-size: 7px;
+    line-height: 8px;
+    text-align: center;
+    color: #00ac11;
+    box-sizing: border-box;
+`
+
+const StyledRewardsAPYContainer = styled.div`
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+`
+
+const StyledRewardsAPY = styled.div`
+    //font-size: 2.2em;
+    font-weight: 700;
+    text-decoration: line-through;
+`
+
+const StyledRewardsAPYWithBoost = styled.div`
+    color: #00ac11;
+    //font-size: 2.2em;
+    font-weight: 700;
+    margin-left: 8px;
+`
+
 export function StrategyTable({
     headers,
     rows,
@@ -60,7 +106,22 @@ export function StrategyTable({
             setSorting={setSorting}
             compactQuery="upToMedium"
             rows={rows.map(
-                ({ pair, rewards, tvl, apy, userPosition, earnPlatform, earnAddress, earnLink, strategyType }, i) => {
+                (
+                    {
+                        pair,
+                        rewards,
+                        tvl,
+                        apy,
+                        userPosition,
+                        earnPlatform,
+                        earnAddress,
+                        earnLink,
+                        strategyType,
+                        apr,
+                        boostAPR,
+                    },
+                    i
+                ) => {
                     // const LSTS = ['RETH', 'APXETH', 'WSTETH']
                     // const isLST = LSTS.includes(pair[0])
                     // const isAPXETH = pair.includes('APXETH')
@@ -139,19 +200,78 @@ export function StrategyTable({
                                 },
                                 {
                                     content: (
-                                        <div style={{ flexDirection: 'row', display: 'flex', alignItems: 'center' }}>
+                                        <Flex $width="100%" $justify="flex-start" $align="center" $gap={12}>
                                             <Text $fontWeight={700}>
-                                                {strategyType === 'deposit'
-                                                    ? '40% - 50%'
-                                                    : apy
-                                                    ? formatNumberWithStyle(apy, {
-                                                          style: 'percent',
-                                                          scalingFactor: 100,
-                                                          maxDecimals: 1,
-                                                          suffixed: true,
-                                                      })
+                                                {!!boostAPR && boostAPR.myBoost > 0
+                                                    ? formatNumberWithStyle(boostAPR.myBoost, {
+                                                          maxDecimals: 2,
+                                                          suffixed: false,
+                                                      }) + 'x'
                                                     : '-'}
                                             </Text>
+                                            {!!boostAPR && boostAPR.myBoost > 0 && (
+                                                <BadgeWrapper>
+                                                    <Badge>BOOST</Badge>
+                                                </BadgeWrapper>
+                                            )}
+                                        </Flex>
+                                    ),
+                                },
+                                {
+                                    content: (
+                                        <div style={{ flexDirection: 'row', display: 'flex', alignItems: 'center' }}>
+                                            {!!boostAPR && boostAPR.myBoost ? (
+                                                boostAPR.baseAPR === boostAPR.myBoostedAPR ? (
+                                                    <Text $fontWeight={700}>
+                                                        {formatNumberWithStyle(boostAPR.baseAPR / 100, {
+                                                            style: 'percent',
+                                                            scalingFactor: 100,
+                                                            maxDecimals: 1,
+                                                            suffixed: true,
+                                                        })}
+                                                    </Text>
+                                                ) : (
+                                                    <StyledRewardsAPYContainer>
+                                                        <StyledRewardsAPY>
+                                                            {formatNumberWithStyle(boostAPR.baseAPR / 100, {
+                                                                style: 'percent',
+                                                                scalingFactor: 100,
+                                                                maxDecimals: 1,
+                                                                suffixed: true,
+                                                            })}
+                                                        </StyledRewardsAPY>
+                                                        <StyledRewardsAPYWithBoost>
+                                                            {' '}
+                                                            {formatNumberWithStyle(boostAPR.myBoostedAPR / 100, {
+                                                                style: 'percent',
+                                                                scalingFactor: 100,
+                                                                maxDecimals: 1,
+                                                                suffixed: true,
+                                                            })}
+                                                        </StyledRewardsAPYWithBoost>
+                                                    </StyledRewardsAPYContainer>
+                                                )
+                                            ) : (
+                                                <Text $fontWeight={700}>
+                                                    {strategyType === 'deposit'
+                                                        ? '40% - 50%'
+                                                        : apr
+                                                        ? formatNumberWithStyle(apr, {
+                                                              style: 'percent',
+                                                              scalingFactor: 100,
+                                                              maxDecimals: 1,
+                                                              suffixed: true,
+                                                          })
+                                                        : apy
+                                                        ? formatNumberWithStyle(apy, {
+                                                              style: 'percent',
+                                                              scalingFactor: 100,
+                                                              maxDecimals: 1,
+                                                              suffixed: true,
+                                                          })
+                                                        : '-'}
+                                                </Text>
+                                            )}
                                             {/* {(isAPXETH || isPXETH) && (
                                                 <BoostBadge>
                                                     <Flex $justify="flex-start" $align="center">
@@ -217,7 +337,9 @@ export function StrategyTable({
 }
 
 const TableHeader = styled(Grid)`
-    grid-template-columns: 340px minmax(100px, 1fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(100px, 1fr) 220px;
+    grid-template-columns:
+        340px minmax(100px, 1fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(100px, 1fr)
+        220px;
     align-items: center;
     padding: 0px;
     padding-left: 6px;
@@ -304,7 +426,6 @@ function EarnEmissionTooltip({ rewards, earnPlatform, earnLink, strategyType }: 
                     Velodrome propotional to their amount of haiVELO deposited.
                     <br />
                     <br />
-                    Current APY (40% - 50%) is a rough estimate based on the current Velodrome voting rewards.
                 </Text>
             </Flex>
         )

--- a/src/containers/Earn/index.tsx
+++ b/src/containers/Earn/index.tsx
@@ -4,6 +4,18 @@ import { NavContainer } from '~/components/NavContainer'
 import { StrategyTable } from './StrategyTable'
 import { CheckboxButton } from '~/components/CheckboxButton'
 import { SortByDropdown } from '~/components/SortByDropdown'
+import { WrapperAdProps, WrapperAd } from '~/components/WrapperAd'
+
+const wrappers: WrapperAdProps[] = [
+    {
+        heading: 'OP REWARDS',
+        status: 'NOW LIVE',
+        description: 'Earn OP tokens daily by participating in incentive campaigns.',
+        cta: 'Provide Liquidity',
+        ctaLink: 'https://app.uniswap.org/explore/pools/optimism/0x146b020399769339509c98b7b353d19130c150ec',
+        tokenImages: ['OP'],
+    },
+]
 
 export function Earn() {
     const { headers, rows, loading, error, uniError, veloError, sorting, setSorting, filterEmpty, setFilterEmpty } =
@@ -36,6 +48,11 @@ export function Earn() {
                 sorting={sorting}
                 setSorting={setSorting}
             />
+            <>
+                {wrappers.map((wrapper, i) => (
+                    <WrapperAd key={i} bgVariant={i} {...wrapper} />
+                ))}
+            </>
         </NavContainer>
     )
 }

--- a/src/containers/Header/MobileMenu.tsx
+++ b/src/containers/Header/MobileMenu.tsx
@@ -37,6 +37,7 @@ import {
     TrendingUp,
     Tv,
     User,
+    Lock,
 } from 'react-feather'
 import { Twitter } from '~/components/Icons/Twitter'
 import { Telegram } from '~/components/Icons/Telegram'
@@ -103,14 +104,21 @@ export function MobileMenu({ active, setActive, showWrapEth }: MobileMenuProps) 
                                     Earn
                                 </BrandedDropdown.Item>
                                 <BrandedDropdown.Item
-                                    href="/learn"
-                                    icon={<Grid size={18} />}
-                                    active={location.pathname === '/learn'}
+                                    href="/stake"
+                                    icon={<Lock size={18} />}
+                                    active={location.pathname === '/stake'}
                                 >
-                                    Learn
+                                    Stake
                                 </BrandedDropdown.Item>
                             </>
                         )}
+                        <BrandedDropdown.Item
+                            href="/learn"
+                            icon={<Grid size={18} />}
+                            active={location.pathname === '/learn'}
+                        >
+                            Learn
+                        </BrandedDropdown.Item>
                         <BrandedDropdown.Item
                             href="/auctions"
                             icon={<ShoppingBag size={18} />}

--- a/src/containers/Header/index.tsx
+++ b/src/containers/Header/index.tsx
@@ -187,9 +187,12 @@ export function Header({ tickerActive = false }: HeaderProps) {
                                         <Link href="/earn" $textDecoration="none">
                                             <HeaderLink $active={location.pathname === '/earn'}>EARN</HeaderLink>
                                         </Link>
-                                        <Link href="/learn" $textDecoration="none">
-                                            <HeaderLink $active={location.pathname === '/learn'}>LEARN</HeaderLink>
+                                        <Link href="/stake" $textDecoration="none">
+                                            <HeaderLink $active={location.pathname === '/stake'}>STAKE</HeaderLink>
                                         </Link>
+                                        {/* <Link href="/learn" $textDecoration="none">
+                                            <HeaderLink $active={location.pathname === '/learn'}>LEARN</HeaderLink>
+                                        </Link> */}
                                     </>
                                 )
                             ))}

--- a/src/containers/Shared.tsx
+++ b/src/containers/Shared.tsx
@@ -31,6 +31,7 @@ import { ClaimModal } from '~/components/Modal/ClaimModal'
 import { IntentionHeader } from '~/components/IntentionHeader'
 import { HaiAlert } from '~/components/HaiAlert'
 import { StartAuction } from './Auctions/StartAuction'
+import { StakingClaimModal } from '~/components/Modal/StakingClaimModal'
 
 type Props = {
     children: ReactChildren
@@ -260,6 +261,7 @@ export function Shared({ children }: Props) {
             {!isSplash && <ParallaxBackground />}
             <Header tickerActive={!isSplash} />
             <ClaimModal />
+            <StakingClaimModal />
             {!isSplash && <WaitingModal />}
 
             {/* {SYSTEM_STATUS && SYSTEM_STATUS.toLowerCase() === 'shutdown' && (

--- a/src/containers/Stake/Activity.tsx
+++ b/src/containers/Stake/Activity.tsx
@@ -1,0 +1,30 @@
+import { useStakingData } from '~/hooks/useStakingData'
+import { StakingActivityTable } from './StakingActivityTable'
+import styled from 'styled-components'
+import { Loader } from '~/components/Loader'
+
+export function StakeActivity() {
+    const { stakingData, loading } = useStakingData()
+
+    if (loading) {
+        return (
+            <Container>
+                <Loader size={32} />
+            </Container>
+        )
+    }
+
+    return (
+        <Container>
+            <StakingActivityTable positions={stakingData.stakingPositions} loading={loading} />
+        </Container>
+    )
+}
+
+const Container = styled.div`
+    width: 100%;
+    min-height: 200px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`

--- a/src/containers/Stake/Manage/ManageStaking.tsx
+++ b/src/containers/Stake/Manage/ManageStaking.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { ActionState, VaultAction, formatNumberWithStyle } from '~/utils'
+import { useStoreActions, useStoreState } from '~/store'
+import { useVault } from '~/providers/VaultProvider'
+// import { formatCollateralLabel } from '~/utils'
+import styled from 'styled-components'
+import { CenteredFlex, Flex, HaiButton, Text } from '~/styles'
+import { NumberInput } from '~/components/NumberInput'
+// import { WrapETHModal } from '~/components/Modal/WrapETHModal'
+import { ManageStakingError } from './ManageStakingError'
+import { CheckBox } from '~/components/CheckBox'
+// import { VaultTxModal } from '~/components/Modal/VaultTxModal'
+import { StakingTxModal } from '~/components/Modal/StakingTxModal'
+
+// import { Info } from '~/components/Icons/Info'
+import { useBalances, useEthersSigner } from '~/hooks'
+import { useStakingData } from '~/hooks/useStakingData'
+// import { Loader } from '~/components/Loader'
+import { AvailabilityBadge } from '~/components/AvailabilityBadge'
+// import { stakingModel } from '~/model/stakingModel'
+import { formatTimeFromSeconds } from '~/utils/time'
+import { useAccount } from 'wagmi'
+
+type StakingSimulation = {
+    stakingAmount: string
+    unstakingAmount: string
+    setStakingAmount: (amount: string) => void
+    setUnstakingAmount: (amount: string) => void
+}
+
+type ManageStakingProps = {
+    simulation: StakingSimulation
+}
+
+export function ManageStaking({ simulation }: ManageStakingProps) {
+    const { stakingAmount, unstakingAmount, setStakingAmount, setUnstakingAmount } = simulation
+    const [, kiteBalance] = useBalances(['HAI', 'KITE'])
+    const { stakingData, cooldownPeriod, loading: stakingDataLoading, refetchAll } = useStakingData()
+    const signer = useEthersSigner()
+    const { address } = useAccount()
+
+    const { stakingModel: stakingState } = useStoreState((state) => state)
+
+    const availableKite = formatNumberWithStyle(kiteBalance.raw, {
+        maxDecimals: 0,
+    })
+
+    const stakedKite = useMemo(() => {
+        if (stakingDataLoading) return null
+        return formatNumberWithStyle(stakingData.stakedBalance, {
+            maxDecimals: 2,
+            minDecimals: 0,
+        })
+    }, [stakingData.stakedBalance, stakingDataLoading])
+
+    const pendingWithdrawal = useMemo(() => {
+        if (!address) return null
+
+        const pW = stakingState.pendingWithdrawals[address.toLowerCase()]
+
+        if (!pW) return null
+
+        const remainingTime = Number(pW.timestamp) + Number(cooldownPeriod) - Date.now() / 1000
+
+        let availableIn
+        if (remainingTime <= 0) {
+            availableIn = 'now'
+        } else if (remainingTime < 3600) {
+            // less than 1 hour
+            availableIn = `${Math.ceil(remainingTime / 60)} mins `
+        } else if (remainingTime < 86400) {
+            // less than 1 day
+            availableIn = `${Math.ceil(remainingTime / 3600)} hours`
+        } else {
+            availableIn = `${Math.ceil(remainingTime / 86400)} days`
+        }
+
+        return {
+            amount: formatNumberWithStyle(pW.amount, {
+                maxDecimals: 2,
+                minDecimals: 2,
+            }),
+            availableIn,
+        }
+    }, [stakingData.pendingWithdrawal, cooldownPeriod, stakingState, address])
+
+    const isUnStaking = Number(unstakingAmount) > 0
+    const isStaking = Number(stakingAmount) > 0
+
+    const {
+        // vaultModel: vaultActions,
+        popupsModel: { toggleModal },
+        stakingModel: stakingActions,
+        popupsModel: popupsActions,
+    } = useStoreActions((actions) => actions)
+    const { stakingModel: stakingStates } = useStoreState((state) => state)
+
+    const { action, formState, collateral } = useVault()
+
+    const isWithdraw = action === VaultAction.WITHDRAW_REPAY || action === VaultAction.WITHDRAW_BORROW
+    // const isRepay = action === VaultAction.WITHDRAW_REPAY || action === VaultAction.DEPOSIT_REPAY
+
+    const [reviewActive, setReviewActive] = useState(false)
+    const [withdrawActive, setWithdrawActive] = useState(false)
+
+    // Reset input values after a successful transaction
+    const clearInputs = () => {
+        setStakingAmount('')
+        setUnstakingAmount('')
+    }
+
+    useEffect(() => {
+        toggleModal({
+            modal: 'reviewTx',
+            isOpen: reviewActive,
+        })
+    }, [reviewActive, toggleModal])
+    useEffect(() => {
+        toggleModal({
+            modal: 'withdraw',
+            isOpen: withdrawActive,
+        })
+    }, [withdrawActive, toggleModal])
+
+    /*if (stakingDataLoading) {
+        return (
+            <Container>
+                <Header>
+                    <Flex $width="100%" $justify="center" $align="center">
+                        <Loader size={32} />
+                    </Flex>
+                </Header>
+            </Container>
+        )
+    }*/
+
+    return (
+        <>
+            {withdrawActive && (
+                <StakingTxModal
+                    isStaking={false}
+                    amount={
+                        isUnStaking
+                            ? unstakingAmount
+                            : isStaking
+                            ? stakingAmount
+                            : pendingWithdrawal
+                            ? pendingWithdrawal.amount
+                            : ''
+                    }
+                    stakedAmount={stakingData.stakedBalance}
+                    onClose={() => {
+                        clearInputs()
+                        setWithdrawActive(false)
+                        toggleModal({
+                            modal: 'withdraw',
+                            isOpen: false,
+                        })
+                    }}
+                    onSuccess={clearInputs}
+                    isWithdraw={true}
+                />
+            )}
+            {reviewActive && (
+                <StakingTxModal
+                    isStaking={!isUnStaking}
+                    amount={
+                        isUnStaking
+                            ? unstakingAmount
+                            : isStaking
+                            ? stakingAmount
+                            : pendingWithdrawal
+                            ? pendingWithdrawal.amount
+                            : ''
+                    }
+                    stakedAmount={stakingData.stakedBalance}
+                    onClose={() => {
+                        setReviewActive(false)
+                        toggleModal({
+                            modal: 'reviewTx',
+                            isOpen: false,
+                        })
+                    }}
+                    onSuccess={clearInputs}
+                    isWithdraw={false}
+                />
+            )}
+            <Container>
+                <Header>
+                    <Flex $width="100%" $justify="space-between" $align="center">
+                        <Text $fontWeight={700}>Manage KITE Staking</Text>
+                        {(Number(stakingAmount) > 0 || Number(unstakingAmount) > 0) && (
+                            <Text
+                                $color="rgba(0,0,0,0.5)"
+                                $fontSize="0.8em"
+                                $textDecoration="underline"
+                                onClick={clearInputs}
+                                style={{ cursor: 'pointer' }}
+                            >
+                                Clear All
+                            </Text>
+                        )}
+                    </Flex>
+                </Header>
+                <Body>
+                    <NumberInput
+                        label={
+                            <CenteredFlex $gap={8}>
+                                <CheckBox checked={!!stakingAmount && Number(stakingAmount) > 0} size={14} />
+                                <Text>Stake</Text>
+                            </CenteredFlex>
+                        }
+                        subLabel={`Max ${availableKite} KITE`}
+                        placeholder="Staking Amount"
+                        unitLabel={'KITE'}
+                        onChange={(value: string) => {
+                            setUnstakingAmount('0')
+                            setStakingAmount(value)
+                        }}
+                        value={stakingAmount}
+                        onMax={() => {
+                            setUnstakingAmount('0')
+                            setStakingAmount(kiteBalance.raw.toString())
+                        }}
+                        conversion={
+                            stakingAmount && Number(stakingAmount) > 0
+                                ? `~${formatNumberWithStyle(
+                                      parseFloat(collateral.priceInUSD || '0') * parseFloat(stakingAmount),
+                                      { style: 'currency' }
+                                  )}`
+                                : ''
+                        }
+                        style={!isWithdraw ? undefined : { opacity: 0.4 }}
+                    />
+                    <NumberInput
+                        label={
+                            <CenteredFlex $gap={8}>
+                                <CheckBox checked={!!unstakingAmount && Number(unstakingAmount) > 0} size={14} />
+                                <Text>Unstake</Text>
+                            </CenteredFlex>
+                        }
+                        subLabel={`Max ${stakedKite} KITE`}
+                        placeholder="Unstaking Amount"
+                        unitLabel={'stKITE'}
+                        onChange={(value: string) => {
+                            setStakingAmount('0')
+                            setUnstakingAmount(value)
+                        }}
+                        value={unstakingAmount}
+                        onMax={() => {
+                            setStakingAmount('0')
+                            setUnstakingAmount(stakingData.stakedBalance)
+                        }}
+                        conversion={
+                            formState.deposit && Number(formState.deposit) > 0
+                                ? `~${formatNumberWithStyle(
+                                      parseFloat(collateral.priceInUSD || '0') * parseFloat(formState.deposit),
+                                      { style: 'currency' }
+                                  )}`
+                                : ''
+                        }
+                        style={!isWithdraw ? undefined : { opacity: 0.4 }}
+                    />
+                    <Text $fontSize="0.85em" $color="rgba(0,0,0,0.85)">
+                        stKITE has a {formatTimeFromSeconds(Number(stakingStates.cooldownPeriod))} cooldown period after
+                        unstaking.
+                    </Text>
+                    {pendingWithdrawal && (
+                        <div
+                            style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                width: '100%',
+                            }}
+                        >
+                            <Text $fontSize="0.85em">{`${pendingWithdrawal.amount} KITE available to claim in`}</Text>
+                            <AvailabilityBadge>{`${pendingWithdrawal.availableIn}`}</AvailabilityBadge>
+                            <HaiButton
+                                $variant="yellowish"
+                                $size="small"
+                                onClick={async () => {
+                                    if (pendingWithdrawal.availableIn === 'now') {
+                                        setWithdrawActive(true)
+                                        toggleModal({
+                                            modal: 'withdraw',
+                                            isOpen: true,
+                                        })
+                                    } else {
+                                        if (!signer) return
+                                        try {
+                                            popupsActions.setIsWaitingModalOpen(true)
+                                            popupsActions.setWaitingPayload({
+                                                title: 'Waiting For Confirmation',
+                                                text: 'Cancel Withdrawal',
+                                                hint: 'Confirm this transaction in your wallet',
+                                                status: ActionState.LOADING,
+                                            })
+
+                                            await stakingActions.cancelWithdrawal({ signer })
+
+                                            await refetchAll({ cancelWithdrawalAmount: pendingWithdrawal.amount })
+                                            popupsActions.setIsWaitingModalOpen(false)
+                                            popupsActions.setWaitingPayload({ status: ActionState.NONE })
+                                        } catch (error) {
+                                            console.error('Failed to cancel withdrawal:', error)
+                                        }
+                                    }
+                                }}
+                            >
+                                {pendingWithdrawal.availableIn === 'now' ? 'Claim' : 'Cancel'}
+                            </HaiButton>
+                        </div>
+                    )}
+                </Body>
+                <Footer>
+                    <ManageStakingError />
+                    <HaiButton
+                        $variant="yellowish"
+                        $width="100%"
+                        $justify="center"
+                        disabled={
+                            (Number(stakingAmount) <= 0 && Number(unstakingAmount) <= 0) ||
+                            Number(stakingAmount) > Number(kiteBalance.raw) ||
+                            Number(unstakingAmount) > Number(stakingData.stakedBalance)
+                        }
+                        onClick={() => {
+                            setReviewActive(true)
+                        }}
+                    >
+                        {isUnStaking ? 'Unstake' : 'Stake'}
+                    </HaiButton>
+                </Footer>
+            </Container>
+        </>
+    )
+}
+
+const Container = styled(Flex).attrs((props) => ({
+    $column: true,
+    $shrink: 0,
+    ...props,
+}))`
+    max-width: 100%;
+    height: 592px;
+    margin-bottom: -143px;
+    background-color: #f7f1ff;
+    border-radius: 24px;
+    border: ${({ theme }) => theme.border.medium};
+
+    ${({ theme }) => theme.mediaWidth.upToMedium`
+        height: auto;
+        min-height: 480px;
+        margin-bottom: -119px;
+    `}
+`
+const Header = styled(Flex).attrs((props) => ({
+    $width: '100%',
+    $column: true,
+    $justify: 'flex-end',
+    $align: 'flex-start',
+    $gap: 12,
+    ...props,
+}))`
+    padding-top: 24px;
+    padding-bottom: 20px;
+    border-bottom: ${({ theme }) => theme.border.thin};
+
+    & > *:first-child {
+        padding: 0 24px;
+    }
+`
+const Body = styled(Flex).attrs((props) => ({
+    $width: '100%',
+    $column: true,
+    $justify: 'flex-start',
+    $align: 'flex-start',
+    $gap: 24,
+    $grow: 1,
+    $shrink: 1,
+    ...props,
+}))`
+    height: 100%;
+    padding: 24px;
+    overflow: auto;
+`
+// const WrapEthText = styled(Text).attrs((props) => ({
+//     $textAlign: 'right',
+//     $color: 'rgba(0,0,0,0.5)',
+//     $fontSize: '0.67em',
+//     ...props,
+// }))`
+//     width: 100%;
+//     margin-top: 8px;
+//     cursor: pointer;
+// `
+
+const Footer = styled(CenteredFlex).attrs((props) => ({
+    $column: true,
+    $gap: 12,
+    ...props,
+}))`
+    width: 100%;
+    padding: 24px;
+    border-top: ${({ theme }) => theme.border.thin};
+`

--- a/src/containers/Stake/Manage/ManageStakingError.tsx
+++ b/src/containers/Stake/Manage/ManageStakingError.tsx
@@ -1,0 +1,44 @@
+import { VaultAction, VaultInfoError } from '~/utils'
+import { useVault } from '~/providers/VaultProvider'
+
+import styled from 'styled-components'
+import { CenteredFlex, Text } from '~/styles'
+
+export function ManageStakingError() {
+    const { action, formState, error, errorMessage } = useVault()
+
+    if (!error) return null
+
+    if (error === VaultInfoError.ZERO_AMOUNT) {
+        switch (action) {
+            case VaultAction.CREATE:
+            case VaultAction.DEPOSIT_BORROW:
+                if (!formState.deposit || !formState.borrow) return null
+                break
+            case VaultAction.DEPOSIT_REPAY:
+                if (!formState.deposit || !formState.repay) return null
+                break
+            case VaultAction.WITHDRAW_BORROW:
+                if (!formState.withdraw || !formState.borrow) return null
+                break
+            case VaultAction.WITHDRAW_REPAY:
+                if (!formState.withdraw || !formState.repay) return null
+                break
+        }
+    }
+
+    return (
+        <Container>
+            <Text $fontSize="0.8em" $color="red" $textAlign="left">
+                Error: {errorMessage}
+            </Text>
+        </Container>
+    )
+}
+
+const Container = styled(CenteredFlex)`
+    width: 100%;
+    & > * {
+        width: fit-content;
+    }
+`

--- a/src/containers/Stake/Manage/Overview.tsx
+++ b/src/containers/Stake/Manage/Overview.tsx
@@ -1,0 +1,316 @@
+import { useMemo } from 'react'
+// import { useTranslation } from 'react-i18next'
+// import { formatCollateralLabel } from '~/utils'
+import { Status, formatNumberWithStyle } from '~/utils'
+// import { useStoreState } from '~/store'
+// import { useVault } from '~/providers/VaultProvider'
+// import { useEarnStrategies } from '~/hooks'
+// import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { useStakingSummary } from '~/hooks/useStakingSummary'
+import { Loader } from '~/components/Loader'
+// import { ComingSoon } from '~/components/ComingSoon'
+
+import styled from 'styled-components'
+import { type DashedContainerProps, DashedContainerStyle, Flex, Grid, Text, CenteredFlex } from '~/styles'
+import { Swirl } from '~/components/Icons/Swirl'
+import { StatusLabel } from '~/components/StatusLabel'
+import { OverviewProgressStat, OverviewStat } from './OverviewStat'
+// import { AlertTriangle, ArrowLeft, ArrowRight } from 'react-feather'
+// import { useBoost } from '~/hooks/useBoost'
+// import { BigNumber, utils } from 'ethers'
+type StakingSimulation = {
+    stakingAmount: string
+    unstakingAmount: string
+    setStakingAmount: (amount: string) => void
+    setUnstakingAmount: (amount: string) => void
+}
+
+type OverviewProps = {
+    simulation: StakingSimulation
+}
+
+export function Overview({ simulation }: OverviewProps) {
+    const { stakingAmount, unstakingAmount } = simulation
+    // const { t } = useTranslation()
+    const {
+        loading,
+        kitePrice,
+        totalStaked,
+        myStaked,
+        myShare,
+        stakingApr,
+        boost,
+        calculateSimulatedValues,
+        isOptimistic,
+    } = useStakingSummary()
+
+    // Calculate simulated values if simulation values are provided
+    const simValues = useMemo(
+        () => calculateSimulatedValues(stakingAmount, unstakingAmount),
+        [stakingAmount, unstakingAmount, calculateSimulatedValues]
+    )
+
+    // Tooltip content for boosted value
+    const myBoostedValueToolTip = (
+        <div style={{ width: '100%' }}>
+            <div style={{ marginBottom: '10px' }}>
+                <Text $fontSize=".9rem" $fontWeight={700}>
+                    haiVELO
+                </Text>
+                <Text $fontSize=".9rem">
+                    {formatNumberWithStyle(boost.haiVeloPositionValue, {
+                        minDecimals: 2,
+                        maxDecimals: 2,
+                        style: 'currency',
+                    })}{' '}
+                    +{' '}
+                    {formatNumberWithStyle(boost.haiVeloBoost, {
+                        minDecimals: 0,
+                        maxDecimals: 2,
+                    })}
+                    x Boost
+                </Text>
+            </div>
+            <div>
+                <Text $fontSize=".9rem" $fontWeight={700}>
+                    HAI/WETH LP
+                </Text>
+                <Text $fontSize=".9rem">
+                    {formatNumberWithStyle(boost.userLPPositionValue, {
+                        minDecimals: 2,
+                        maxDecimals: 2,
+                        style: 'currency',
+                    })}{' '}
+                    +{' '}
+                    {formatNumberWithStyle(boost.lpBoost, {
+                        minDecimals: 0,
+                        maxDecimals: 2,
+                    })}
+                    x Boost
+                </Text>
+            </div>
+        </div>
+    )
+
+    return (
+        <Container>
+            <Header>
+                <Flex $justify="flex-start" $align="center" $gap={12}>
+                    <Text $fontWeight={700}>Staking Overview</Text>
+                    {simValues.simulationMode && (
+                        <StatusLabel status={Status.CUSTOM} background="gradient">
+                            <CenteredFlex $gap={8}>
+                                <Swirl size={14} />
+                                <Text $fontSize="0.67rem" $fontWeight={700}>
+                                    Simulation
+                                </Text>
+                            </CenteredFlex>
+                        </StatusLabel>
+                    )}
+                    {isOptimistic && (
+                        <StatusLabel status={Status.POSITIVE}>
+                            <CenteredFlex $gap={8}>
+                                <Loader size={16} hideSpinner={false} color="#00AC11"></Loader>
+                                <Text $fontSize="0.67rem" $fontWeight={700}>
+                                    Confirming Transaction
+                                </Text>
+                            </CenteredFlex>
+                        </StatusLabel>
+                    )}
+                </Flex>
+
+                <Flex $justify="flex-end" $align="center" $gap={12} $fontSize="0.8em">
+                    <Text>
+                        KITE: &nbsp;
+                        <strong>
+                            {formatNumberWithStyle(kitePrice, {
+                                minDecimals: 2,
+                                maxDecimals: 2,
+                                style: 'currency',
+                            })}
+                        </strong>
+                    </Text>
+                </Flex>
+            </Header>
+            <Inner $borderOpacity={0.2}>
+                <OverviewStat
+                    loading={loading}
+                    value={totalStaked.amountFormatted}
+                    token="KITE"
+                    tokenLabel={'stKITE'}
+                    simulatedToken="stKITE"
+                    label="Total Staked KITE"
+                    convertedValue={totalStaked.usdValueFormatted}
+                    simulatedValue={
+                        simValues.totalStakedAfterTx !== totalStaked.amount
+                            ? formatNumberWithStyle(simValues.totalStakedAfterTx, {
+                                  minDecimals: 0,
+                                  maxDecimals: 2,
+                              })
+                            : undefined
+                    }
+                    labelOnTop
+                />
+                <OverviewStat
+                    loading={loading}
+                    value={myStaked.effectiveAmountFormatted}
+                    token="KITE"
+                    tokenLabel={'stKITE'}
+                    simulatedToken="stKITE"
+                    label="My Staked KITE"
+                    convertedValue={myStaked.usdValueFormatted}
+                    simulatedValue={
+                        simValues.myStakedAfterTx !== myStaked.effectiveAmount
+                            ? formatNumberWithStyle(simValues.myStakedAfterTx, {
+                                  minDecimals: 0,
+                                  maxDecimals: 2,
+                              })
+                            : undefined
+                    }
+                    labelOnTop
+                />
+                <OverviewStat
+                    loading={loading}
+                    value={`${formatNumberWithStyle(myShare.value, {
+                        minDecimals: 2,
+                        maxDecimals: 2,
+                    })}%`}
+                    label="My stKITE Share"
+                    simulatedValue={
+                        simValues.myShareAfterTx !== myShare.value
+                            ? `${formatNumberWithStyle(simValues.myShareAfterTx, {
+                                  minDecimals: 0,
+                                  maxDecimals: 2,
+                              })}%`
+                            : undefined
+                    }
+                />
+                <OverviewStat
+                    isComingSoon={false}
+                    loading={loading}
+                    value={stakingApr.formatted}
+                    label="Staking APR"
+                    tooltip={`The base staking APR is determined by protocol fees accrued in system surplus and the stream rate set by the DAO.`}
+                />
+
+                <OverviewStat
+                    isComingSoon={false}
+                    loading={loading}
+                    value={boost.boostedValueFormatted}
+                    label="My Boosted Value"
+                    tooltip={myBoostedValueToolTip as any}
+                />
+                <OverviewProgressStat
+                    loading={loading}
+                    isComingSoon={false}
+                    value={boost.netBoostValue}
+                    label="My Net Boost:"
+                    simulatedValue={
+                        boost.netBoostValue !== simValues.netBoostAfterTx
+                            ? `${formatNumberWithStyle(simValues.netBoostAfterTx, {
+                                  minDecimals: 2,
+                                  maxDecimals: 2,
+                              })}x`
+                            : undefined
+                    }
+                    alert={{ value: 'BOOST', status: Status.POSITIVE }}
+                    fullWidth
+                    progress={{
+                        progress: boost.netBoostValue - 1,
+                        label: `${formatNumberWithStyle(boost.netBoostValue, {
+                            minDecimals: 2,
+                            maxDecimals: 2,
+                        })}x`,
+                    }}
+                    simulatedProgress={
+                        boost.netBoostValue !== simValues.netBoostAfterTx
+                            ? {
+                                  progress: simValues.netBoostAfterTx - 1,
+                                  label: `${formatNumberWithStyle(simValues.netBoostAfterTx, {
+                                      minDecimals: 2,
+                                      maxDecimals: 2,
+                                  })}x`,
+                              }
+                            : undefined
+                    }
+                    colorLimits={[0.25, 0.5, 0.75]}
+                    labels={[
+                        { progress: 0, label: '1x' },
+                        { progress: 0.25, label: '1.25x' },
+                        { progress: 0.5, label: '1.5x' },
+                        { progress: 0.75, label: '1.75x' },
+                        { progress: 1, label: '2x' },
+                    ]}
+                    tooltip={`Max Net Boost is achieved when your KITE staking share is equal to or greater than the weighted average proportions of your incentivized positions.`}
+                />
+            </Inner>
+        </Container>
+    )
+}
+
+const Container = styled(Flex).attrs((props) => ({
+    $width: '100%',
+    $column: true,
+    $justify: 'flex-start',
+    $align: 'flex-start',
+    ...props,
+}))``
+const Header = styled(Flex).attrs((props) => ({
+    $width: '100%',
+    $justify: 'space-between',
+    $align: 'center',
+    $gap: 12,
+    ...props,
+}))`
+    min-height: 60px;
+    padding: 24px 0px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+    `}
+`
+
+const Inner = styled(Grid).attrs((props) => ({
+    $width: '100%',
+    $columns: 'repeat(6, 1fr)',
+    $align: 'stretch',
+    ...props,
+}))<DashedContainerProps>`
+    ${DashedContainerStyle}
+    & > * {
+        padding: 18px;
+        &:nth-child(1) {
+            grid-column: 1 / 4;
+        }
+        &:nth-child(2) {
+            grid-column: 4 / -1;
+        }
+        &:nth-child(3) {
+            grid-column: 1 / 3;
+        }
+        &:nth-child(4) {
+            grid-column: 3 / 5;
+        }
+        &:nth-child(5) {
+            grid-column: 5 / -1;
+        }
+    }
+    &::after {
+        border-top: none;
+        border-right: none;
+    }
+
+    ${({ theme }) => theme.mediaWidth.upToMedium`
+        & > * {
+            &:nth-child(1) {
+                grid-column: 1 / -1;
+            }
+            &:nth-child(2) {
+                grid-column: 1 / -1;
+            }
+            padding: 12px;
+        }
+    `}
+`

--- a/src/containers/Stake/Manage/OverviewStat.tsx
+++ b/src/containers/Stake/Manage/OverviewStat.tsx
@@ -1,0 +1,330 @@
+import type { TokenKey } from '~/types'
+import { Status } from '~/utils'
+import { useMediaQuery } from '~/hooks'
+
+import styled, { css } from 'styled-components'
+import { CenteredFlex, type DashedContainerProps, DashedContainerStyle, Flex, Text } from '~/styles'
+import { StatusLabel } from '~/components/StatusLabel'
+import { TokenArray } from '~/components/TokenArray'
+import { Tooltip } from '~/components/Tooltip'
+import { ProgressIndicator, ProgressIndicatorProps } from '~/components/ProgressIndicator'
+import { ComingSoon } from '~/components/ComingSoon'
+import { Loader } from '~/components/Loader'
+type OverviewStatProps = {
+    token?: TokenKey
+    simulatedToken?: string
+    value: string | number
+    tokenLabel?: string
+    isComingSoon?: boolean
+    label: string
+    labelOnTop?: boolean
+    tooltip?: string
+    convertedValue?: string | number
+    alert?: {
+        value?: string
+        status: Status
+    }
+    simulatedValue?: string
+    fullWidth?: boolean
+    simulationMode?: boolean
+    loading?: boolean
+}
+export function OverviewStat({
+    token,
+    simulatedToken,
+    tokenLabel,
+    isComingSoon = false,
+    value,
+    label,
+    labelOnTop = false,
+    tooltip,
+    convertedValue,
+    alert,
+    simulatedValue,
+    // simulationMode = false,
+    fullWidth = false,
+    loading = false,
+}: OverviewStatProps) {
+    return (
+        <StatContainer $fullWidth={fullWidth}>
+            {isComingSoon ? (
+                <>
+                    <div style={{ width: '100%', marginTop: '20px' }}>
+                        <ComingSoon active={true} width="100%" />
+                    </div>
+                    <div style={{ width: '100%', marginTop: '20px' }}>
+                        <Flex $justify="flex-start" $align="center" $gap={4}>
+                            <Text $fontSize="0.8em" $whiteSpace="nowrap">
+                                {label}
+                            </Text>
+                            {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
+                        </Flex>
+                    </div>
+                </>
+            ) : (
+                <>
+                    {labelOnTop && (
+                        <Flex $justify="flex-start" $align="center" $gap={4}>
+                            <Text $fontSize="0.8em" $whiteSpace="nowrap">
+                                {label}
+                            </Text>
+                            {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
+                        </Flex>
+                    )}
+                    <Flex $align="center" $gap={12}>
+                        {!!token && <TokenArray size={48} tokens={[token]} hideLabel />}
+                        <Flex $column $justify="center" $align="flex-start" $gap={4}>
+                            <ValueContainer>
+                                {loading ? (
+                                    <Loader size={32} hideSpinner={false} color="#FFD641"></Loader>
+                                ) : (
+                                    <>
+                                        <Text $fontSize="1.5em" $fontWeight={700}>
+                                            {value || '--'} {tokenLabel}
+                                        </Text>
+                                        <Text $fontSize="1.2em" $color="rgba(0,0,0,0.6)">
+                                            {convertedValue}
+                                        </Text>
+                                    </>
+                                )}
+                            </ValueContainer>
+                        </Flex>
+                    </Flex>
+                    {!labelOnTop && (
+                        <Flex $justify="flex-start" $align="center" $gap={4}>
+                            <Text $fontSize="0.8em" $whiteSpace="nowrap">
+                                {label}
+                            </Text>
+                            {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
+                        </Flex>
+                    )}
+                    <StatusContainer hidden={!simulatedValue && !alert}>
+                        {!!alert && (
+                            <StatusLabel status={alert.status} size={0.8}>
+                                {alert.value || alert.status}
+                            </StatusLabel>
+                        )}
+                        {!!simulatedValue && !loading && (
+                            <StatusLabel status={Status.CUSTOM} background="gradient" size={0.8}>
+                                <Text $fontSize="0.67rem" $fontWeight={700}>
+                                    {simulatedValue || '--'} {simulatedToken ? simulatedToken : token}
+                                </Text>
+                                <Text $fontSize="0.67rem" $fontWeight={400} $whiteSpace="nowrap">
+                                    After Tx
+                                </Text>
+                            </StatusLabel>
+                        )}
+                        {/* {simulationMode && (
+                            <StatusLabel status={Status.CUSTOM} background="gradient" size={0.8}>
+                                <Text $fontSize="0.67rem" $fontWeight={700}>
+                                    {simulatedValue || '--'} {token}
+                                </Text>
+                                <Text $fontSize="0.67rem" $fontWeight={400} $whiteSpace="nowrap">
+                                    After Tx
+                                </Text>
+                            </StatusLabel>
+                        )} */}
+                    </StatusContainer>
+                </>
+            )}
+        </StatContainer>
+    )
+}
+
+type OverviewProgressStatProps = OverviewStatProps & ProgressIndicatorProps
+export function OverviewProgressStat({
+    value,
+    label,
+    tooltip,
+    isComingSoon = false,
+    alert,
+    simulatedValue,
+    fullWidth = false,
+    loading = false,
+    progress: progressProp,
+    simulatedProgress: simulatedProgressProp,
+    colorLimits,
+    labels,
+    ...otherProps
+}: OverviewProgressStatProps) {
+    const isUpToSmall = useMediaQuery('upToSmall')
+
+    // Ensure value is a number between 1 and 2
+    const clampedValue = Math.min(Math.max(Number(value) || 1, 1), 2)
+
+    // Format the value display with 'x' suffix
+    const formattedValue = `${clampedValue.toFixed(2)}x`
+
+    // Format simulatedValue with 'x' suffix if it exists
+    const formattedSimulatedValue = simulatedValue
+        ? typeof simulatedValue === 'number'
+            ? `${Math.min(Math.max(simulatedValue, 1), 2).toFixed(2)}x`
+            : simulatedValue.endsWith('x')
+            ? simulatedValue
+            : `${simulatedValue}x`
+        : undefined
+
+    // Create progress object if not provided
+    const progressObj = progressProp || {
+        progress: clampedValue - 1,
+        label: formattedValue,
+    }
+
+    // Create simulated progress object if not provided but simulatedValue exists
+    const simulatedProgressObj =
+        simulatedProgressProp ||
+        (formattedSimulatedValue
+            ? {
+                  progress: Number(formattedSimulatedValue.replace('x', '')) - 1,
+                  label: formattedSimulatedValue,
+              }
+            : undefined)
+
+    // Default colorLimits and labels if not provided
+    const defaultColorLimits = [0.25, 0.5, 0.75]
+    const defaultLabels = [
+        { progress: 0, label: '1x' },
+        { progress: 0.25, label: '1.25x' },
+        { progress: 0.5, label: '1.5x' },
+        { progress: 0.75, label: '1.75x' },
+        { progress: 1, label: '2x' },
+    ]
+
+    return (
+        <ProgressStatContainer $fullWidth={fullWidth}>
+            <Flex $width="100%" $justify="space-between" $align="center">
+                <CenteredFlex $gap={4}>
+                    <Text>{label}</Text>
+                    {!isComingSoon && !loading && (
+                        <Text $fontWeight={700} $fontSize="1.25em">
+                            {formattedValue}
+                        </Text>
+                    )}
+                    {!isComingSoon && loading && <Loader size={24} hideSpinner={false} color="#FFD641" />}
+
+                    {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
+                </CenteredFlex>
+                {isComingSoon && <ComingSoon active={true} width="100%" />}
+                <StatusContainer hidden={!(formattedSimulatedValue && !isUpToSmall) && !alert}>
+                    {!isComingSoon && !!alert && (
+                        <StatusLabel status={alert.status} size={0.8}>
+                            {alert.value || alert.status}
+                        </StatusLabel>
+                    )}
+
+                    {!isComingSoon && formattedSimulatedValue && !isUpToSmall && !loading && (
+                        <StatusLabel status={Status.CUSTOM} background="gradient" size={0.8}>
+                            <Text $fontSize="0.67rem" $fontWeight={700}>
+                                {formattedSimulatedValue}
+                            </Text>
+                            <Text $fontSize="0.67rem" $fontWeight={400}>
+                                After Tx
+                            </Text>
+                        </StatusLabel>
+                    )}
+                </StatusContainer>
+            </Flex>
+            {!loading ? (
+                <ProgressIndicator
+                    progress={progressObj}
+                    simulatedProgress={simulatedProgressObj}
+                    colorLimits={colorLimits || defaultColorLimits}
+                    labels={labels || defaultLabels}
+                    {...otherProps}
+                />
+            ) : (
+                <Flex $width="100%" $justify="center" $align="center" $padding="12px 0">
+                    <Loader size={32} hideSpinner={false} color="#FFD641" />
+                </Flex>
+            )}
+            {formattedSimulatedValue && isUpToSmall && !loading && (
+                <Flex $width="100%" $justify="flex-end" $align="center">
+                    <StatusLabel status={Status.CUSTOM} background="gradient" size={0.8}>
+                        <Text $fontSize="0.67rem" $fontWeight={700}>
+                            {formattedSimulatedValue}
+                        </Text>
+                        <Text $fontSize="0.67rem" $fontWeight={400}>
+                            After Tx
+                        </Text>
+                    </StatusLabel>
+                </Flex>
+            )}
+        </ProgressStatContainer>
+    )
+}
+
+const StatContainer = styled(Flex).attrs((props) => ({
+    $column: true,
+    $justify: 'flex-start',
+    $align: 'flex-start',
+    $gap: 4,
+    $borderOpacity: 0.2,
+    ...props,
+}))<DashedContainerProps & { $fullWidth?: boolean }>`
+    ${DashedContainerStyle}
+    ${({ $fullWidth }) =>
+        $fullWidth &&
+        css`
+            grid-column: 1 / -1;
+        `}
+
+    &::after {
+        border-bottom: none;
+        border-left: none;
+    }
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 12px;
+        font-size: 0.8rem;
+    `}
+`
+const ProgressStatContainer = styled(StatContainer)`
+    width: 100%;
+    flex-direction: column;
+    gap: 12px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+        & > *:nth-child(2) {
+            margin-bottom: 8px;
+        }
+    `}
+`
+
+const ValueContainer = styled(Flex).attrs((props) => ({
+    $column: true,
+    $justify: 'flex-start',
+    $align: 'flex-start',
+    $gap: 0,
+    ...props,
+}))`
+    /* ${({ theme }) => theme.mediaWidth.upToSmall`
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    `} */
+`
+
+const StatusContainer = styled(Flex).attrs((props) => ({
+    $justify: 'center',
+    $align: 'center',
+    $gap: 12,
+    ...props,
+}))`
+    ${({ hidden }) =>
+        hidden &&
+        css`
+            display: none;
+        `}
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+        width: 100%;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-end;
+        // justify-content: flex-end;
+        gap: 8px;
+    `}
+`

--- a/src/containers/Stake/StakingActivityTable.tsx
+++ b/src/containers/Stake/StakingActivityTable.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from 'react'
+import styled from 'styled-components'
+import { Grid, Text } from '~/styles'
+import { Table } from '~/components/Table'
+import { ExternalLink } from 'react-feather'
+import { Link } from '~/components/Link'
+import { formatNumberWithStyle } from '~/utils'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import { Sorting } from '~/types'
+
+dayjs.extend(relativeTime)
+
+const BLOCK_EXPLORER = 'https://optimistic.etherscan.io'
+
+function shortenTxHash(hash: string): string {
+    return `${hash.slice(0, 6)}...${hash.slice(-4)}`
+}
+
+type StakingActivityTableProps = {
+    positions: Array<{
+        timestamp: number
+        type: string
+        amount: string
+        transactionHash: string
+    }>
+    loading?: boolean
+}
+
+export function StakingActivityTable({ positions, loading }: StakingActivityTableProps) {
+    const [sorting, setSorting] = useState<Sorting>({
+        key: 'timestamp',
+        dir: 'desc',
+    })
+
+    const headers = useMemo(
+        () => [{ label: 'Time' }, { label: 'Action' }, { label: 'Amount' }, { label: 'Transaction' }],
+        []
+    )
+
+    const rows = useMemo(() => {
+        return positions
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .map((position) => ({
+                timestamp: dayjs(position.timestamp * 1000).fromNow(),
+                type: position.type
+                    .split('_')
+                    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+                    .join(' '),
+                amount: formatNumberWithStyle(Number(position.amount), {
+                    minDecimals: 2,
+                    maxDecimals: 2,
+                }),
+                txHash: position.transactionHash,
+            }))
+    }, [positions])
+
+    return (
+        <Table
+            headers={headers}
+            headerContainer={TableHeader}
+            loading={loading}
+            isEmpty={!positions.length}
+            sorting={sorting}
+            setSorting={setSorting}
+            rows={rows.map((row, i) => (
+                <Table.Row
+                    key={i}
+                    container={TableRow}
+                    headers={headers}
+                    compactQuery="upToMedium"
+                    items={[
+                        {
+                            content: <Text>{row.timestamp}</Text>,
+                        },
+                        {
+                            content: <Text $fontWeight={700}>{row.type}</Text>,
+                        },
+                        {
+                            content: (
+                                <Text>
+                                    {row.amount} <span style={{ fontWeight: 700 }}>$KITE</span>
+                                </Text>
+                            ),
+                        },
+                        {
+                            content: (
+                                <Link href={`${BLOCK_EXPLORER}/tx/${row.txHash}`} target="_blank">
+                                    <TxHashContainer>
+                                        {shortenTxHash(row.txHash)}
+                                        <ExternalLink size={12} />
+                                    </TxHashContainer>
+                                </Link>
+                            ),
+                        },
+                    ]}
+                />
+            ))}
+        />
+    )
+}
+
+const TableHeader = styled(Grid)`
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    align-items: center;
+    padding: 0px 24px;
+    font-size: 0.8rem;
+    margin-bottom: 1em;
+`
+
+const TableRow = styled(TableHeader)`
+    border-radius: 999px;
+
+    margin-bottom: 0.5em;
+
+    ${({ theme }) => theme.mediaWidth.upToMedium`
+        padding: 24px;
+        grid-template-columns: 1fr 1fr;
+        grid-gap: 12px;
+        border-radius: 0px;
+
+        &:not(:first-child) {
+            border-top: ${theme.border.medium};
+        }
+        &:hover {
+            background-color: unset;
+        }
+    `}
+`
+
+const TxHashContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    &:hover {
+        color: ${({ theme }) => theme.colors.primary};
+    }
+`

--- a/src/containers/Stake/Stats.tsx
+++ b/src/containers/Stake/Stats.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from 'react'
+
+import { formatNumberWithStyle, tokenAssets } from '~/utils'
+import { useStoreActions } from '~/store'
+import { HaiButton, Text } from '~/styles'
+import { RewardsTokenArray } from '~/components/TokenArray'
+import { Stats, type StatProps } from '~/components/Stats'
+import { Link } from '~/components/Link'
+import { Loader } from '~/components/Loader'
+// import { RefreshCw } from 'react-feather'
+import { useStakingSummary } from '~/hooks/useStakingSummary'
+import { useStoreState } from 'easy-peasy'
+import { useStakingData } from '~/hooks/useStakingData'
+import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { ethers } from 'ethers'
+
+export function StakeStats() {
+    const {
+        vaultModel: { liquidationData },
+        // popupsModel: { isStakeClaimPopupOpen },
+    } = useStoreState((state) => state)
+    const { popupsModel: popupsActions } = useStoreActions((actions) => actions)
+    const { loading, totalStaked, myStaked, myShare, boost, stakingData } = useStakingSummary()
+
+    const { userRewards } = useStakingData()
+
+    // const [claiming, setClaiming] = useState(false)
+
+    const { prices: veloPrices } = useVelodromePrices()
+
+    const haiPrice = parseFloat(liquidationData?.currentRedemptionPrice || '1')
+    const kitePrice = veloPrices?.KITE.raw
+    const opPrice = liquidationData?.collateralLiquidationData?.OP?.currentPrice.value
+
+    const HAI_ADDRESS = import.meta.env.VITE_HAI_ADDRESS
+    const KITE_ADDRESS = import.meta.env.VITE_KITE_ADDRESS
+    const OP_ADDRESS = import.meta.env.VITE_OP_ADDRESS
+
+    const rewardsDataMap = {
+        [HAI_ADDRESS]: {
+            id: 0,
+            name: tokenAssets.HAI.symbol,
+            tokenImg: tokenAssets.HAI.icon,
+            price: haiPrice,
+        },
+        [KITE_ADDRESS]: {
+            id: 1,
+            name: tokenAssets.KITE.symbol,
+            tokenImg: tokenAssets.KITE.icon,
+            price: kitePrice,
+        },
+        [OP_ADDRESS]: {
+            id: 2,
+            name: tokenAssets.OP.symbol,
+            tokenImg: tokenAssets.OP.icon,
+            price: opPrice,
+        },
+    }
+
+    const stats: StatProps[] = useMemo(() => {
+        if (loading) {
+            return Array(5).fill({
+                header: <Loader size={24} />,
+                label: '',
+            })
+        }
+
+        return [
+            {
+                header: totalStaked.usdValueFormatted,
+                label: 'Staking TVL',
+                tooltip: (
+                    <span>
+                        Total Value Locked (TVL) represents the total amount of KITE tokens staked in the protocol.
+                    </span>
+                ),
+            },
+            {
+                header: myStaked.effectiveAmountFormatted,
+                label: 'My KITE Staked',
+                tooltip: (
+                    <span>
+                        The amount of KITE tokens you have staked in the protocol. Staked KITE (stKITE) provides boosted
+                        rewards.
+                    </span>
+                ),
+            },
+            {
+                header: myShare.percentage,
+                label: 'My stKITE Share',
+                tooltip: (
+                    <span>
+                        Your percentage share of the total staked KITE supply. This determines your proportional share
+                        of staking rewards.
+                    </span>
+                ),
+            },
+            {
+                header: isNaN(boost.netBoostValue) ? '...' : boost.netBoostFormatted,
+                label: 'My Net Boost',
+                tooltip: (
+                    <Text>
+                        Your current boost multiplier based on your staked KITE. Check out the{' '}
+                        <Link href="/earn">earn page</Link> for more information.
+                    </Text>
+                ),
+            },
+            {
+                header: formatNumberWithStyle(
+                    userRewards.reduce((acc, reward) => {
+                        const amount = parseFloat(ethers.utils.formatEther(reward.amount))
+                        const price = rewardsDataMap[reward.tokenAddress as any].price as number
+                        return acc + amount * price
+                    }, 0),
+                    { style: 'currency', minDecimals: 0, maxDecimals: 2 }
+                ) /*stakingData.pendingWithdrawal ? (
+                    formatNumberWithStyle(Number(stakingData.pendingWithdrawal.amount), {
+                        minDecimals: 0,
+                        maxDecimals: 2,
+                    })
+                ) : (
+                    <Loader speed={0.5} icon={<RefreshCw />} />
+                )*/,
+                headerStatus: <RewardsTokenArray tokens={['HAI', 'KITE', 'OP']} hideLabel />,
+                label: 'My Staking Rewards',
+                tooltip: 'Claim your staking rewards. Unclaimed rewards will accrue below and do not expire.',
+                button: (
+                    <HaiButton $variant="yellowish" onClick={() => popupsActions.setIsStakeClaimPopupOpen(true)}>
+                        Claim
+                    </HaiButton>
+                ),
+            },
+        ]
+    }, [loading, totalStaked, myStaked, myShare, boost, stakingData, popupsActions])
+
+    return <Stats stats={stats} columns="repeat(4, 1fr) 1.6fr" fun />
+}

--- a/src/containers/Stake/index.tsx
+++ b/src/containers/Stake/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+
+// import { useEarnStrategies, useMediaQuery } from '~/hooks'
+
+import { NavContainer } from '~/components/NavContainer'
+// import { CheckboxButton } from '~/components/CheckboxButton'
+// import { SortByDropdown } from '~/components/SortByDropdown'
+import { Grid } from '~/styles'
+import styled from 'styled-components'
+import { Overview } from './Manage/Overview'
+import { ManageStaking } from './Manage/ManageStaking'
+import { StakeActivity } from './Activity'
+
+export type StakingSimulation = {
+    stakingAmount: string
+    unstakingAmount: string
+    setStakingAmount: (amount: string) => void
+    setUnstakingAmount: (amount: string) => void
+}
+
+export function Stake() {
+    const [navIndex, setNavIndex] = useState(0)
+    const [stakingAmount, setStakingAmount] = useState('')
+    const [unstakingAmount, setUnstakingAmount] = useState('')
+
+    const simulation: StakingSimulation = {
+        stakingAmount,
+        unstakingAmount,
+        setStakingAmount,
+        setUnstakingAmount,
+    }
+
+    return (
+        <NavContainer
+            navItems={[`Manage`, 'Activity']}
+            selected={navIndex}
+            onSelect={(i: number) => setNavIndex(i)}
+            compactQuery="upToMedium"
+            headerContent={<></>}
+        >
+            {navIndex === 0 ? (
+                <BodyGrid>
+                    <Overview simulation={simulation} />
+                    <ManageStaking simulation={simulation} />
+                </BodyGrid>
+            ) : (
+                <StakeActivity />
+            )}
+        </NavContainer>
+    )
+}
+
+const BodyGrid = styled(Grid)`
+    width: 100%;
+    grid-template-columns: 5fr 3fr;
+    grid-gap: 48px;
+
+    ${({ theme }) => theme.mediaWidth.upToMedium`
+        grid-template-columns: 1fr;
+        grid-gap: 24px;
+        padding: 24px;
+    `}
+`

--- a/src/containers/Vaults/Manage/Overview.tsx
+++ b/src/containers/Vaults/Manage/Overview.tsx
@@ -4,7 +4,7 @@ import { formatCollateralLabel } from '~/utils'
 import { Status, VaultAction, formatNumberWithStyle } from '~/utils'
 import { useStoreState } from '~/store'
 import { useVault } from '~/providers/VaultProvider'
-import { useEarnStrategies } from '~/hooks'
+// import { useEarnStrategies } from '~/hooks'
 
 import styled from 'styled-components'
 import { type DashedContainerProps, DashedContainerStyle, Flex, Grid, Text, CenteredFlex } from '~/styles'
@@ -12,19 +12,122 @@ import { Swirl } from '~/components/Icons/Swirl'
 import { StatusLabel } from '~/components/StatusLabel'
 import { OverviewProgressStat, OverviewStat } from './OverviewStat'
 import { AlertTriangle, ArrowLeft, ArrowRight } from 'react-feather'
+import { useAccount } from 'wagmi'
+import { useHaiVeloData } from '~/hooks/useHaiVeloData'
+import { calculateHaiVeloBoost } from '~/services/boostService'
 
-export function Overview() {
+export function Overview({ isHAIVELO }: { isHAIVELO: boolean }) {
     const { t } = useTranslation()
+    const { address } = useAccount()
+
+    const { userCollateralMapping } = useHaiVeloData()
 
     const {
         vaultModel: { liquidationData },
+        stakingModel: { usersStakingData },
     } = useStoreState((state) => state)
 
-    const { rows } = useEarnStrategies()
+    const HAI_VELO_DAILY_REWARDS = 200
 
-    const { action, vault, collateral, riskStatus, safetyRatio, collateralRatio, simulation, summary } = useVault()
+    const { action, vault, collateral, riskStatus, safetyRatio, collateralRatio, simulation, summary, formState } =
+        useVault()
 
-    const { apy = 0 } = rows.find(({ pair }) => pair[0] === collateral.name) || {}
+    const userHaiVeloBoostData = useMemo(() => {
+        if (!address)
+            return {
+                mystKiteShare: 0,
+                totalKite: 0,
+            }
+
+        const totalHaiVeloDeposited = Object.values(userCollateralMapping).reduce((acc, value) => {
+            return acc + Number(value)
+        }, 0)
+
+        const totalKite = Object.values(usersStakingData).reduce((acc, curr) => acc + Number(curr.stakedBalance), 0)
+
+        console.log(totalKite, usersStakingData)
+
+        const userHaiVeloBoostMap: Record<string, number> = Object.entries(userCollateralMapping).reduce(
+            (acc, [address, value]) => {
+                if (!usersStakingData[address.toLowerCase()]) return { ...acc, [address]: 1 }
+
+                return {
+                    ...acc,
+                    [address]: calculateHaiVeloBoost({
+                        userStakingAmount: Number(usersStakingData[address.toLowerCase()]?.stakedBalance),
+                        totalStakingAmount: Number(totalKite),
+                        userHaiVELODeposited: Number(value),
+                        totalHaiVELODeposited: Number(totalHaiVeloDeposited),
+                    }).haiVeloBoost,
+                }
+            },
+            {}
+        )
+
+        const calculateTotalBoostedValueParticipating = () => {
+            return Object.entries(userCollateralMapping).reduce((acc, [address, value]) => {
+                return acc + Number(value) * userHaiVeloBoostMap[address]
+            }, 0)
+        }
+
+        const mystKiteShare = totalKite ? Number(usersStakingData[address.toLowerCase()]?.stakedBalance) / totalKite : 0
+
+        const totalBoostedValueParticipating = calculateTotalBoostedValueParticipating()
+
+        const baseAPR = totalBoostedValueParticipating
+            ? (HAI_VELO_DAILY_REWARDS / totalBoostedValueParticipating) * 365 * 100
+            : 0
+
+        const myBoost = address ? userHaiVeloBoostMap[address.toLowerCase()] : 1
+
+        const myValueParticipating = address ? userCollateralMapping[address.toLowerCase()] : 0
+
+        const myBoostedValueParticipating = Number(myValueParticipating) * myBoost
+
+        const myBoostedShare = totalBoostedValueParticipating
+            ? myBoostedValueParticipating / totalBoostedValueParticipating
+            : 0
+
+        const simulateBoostAfterDeposit = (amount: number) => {
+            const currentUserDeposit = userCollateralMapping[address.toLowerCase()]
+
+            return calculateHaiVeloBoost({
+                userStakingAmount: Number(usersStakingData[address.toLowerCase()]?.stakedBalance),
+                totalStakingAmount: Number(totalKite),
+                userHaiVELODeposited: Number(currentUserDeposit) + Number(amount),
+                totalHaiVELODeposited: Number(totalHaiVeloDeposited) + Number(amount),
+            }).haiVeloBoost
+        }
+
+        const effectiveDeposit = formState.withdraw
+            ? -1 * Number(formState.withdraw)
+            : formState.deposit
+            ? Number(formState.deposit)
+            : 0
+
+        const simulatedBoostAfterDeposit = simulateBoostAfterDeposit(effectiveDeposit)
+
+        const myHaiVeloShare = Number(myValueParticipating) / Number(totalHaiVeloDeposited)
+
+        const myHaiVeloSimulatedShare =
+            (Number(myValueParticipating) + effectiveDeposit) / (Number(totalHaiVeloDeposited) + effectiveDeposit)
+
+        const myBoostedAPR = myBoost * baseAPR //((myBoostedShare * HAI_VELO_DAILY_REWARDS) / myValueParticipating) * 365 * 100
+
+        return {
+            mystKiteShare,
+            myHaiVeloShare,
+            totalKite,
+            myBoostedShare,
+            baseAPR,
+            myBoost,
+            myValueParticipating,
+            myBoostedValueParticipating,
+            simulatedBoostAfterDeposit,
+            myHaiVeloSimulatedShare,
+            myBoostedAPR,
+        }
+    }, [address, usersStakingData, userCollateralMapping, formState])
 
     const progressProps = useMemo(() => {
         if (!collateralRatio || !safetyRatio || !collateral.liquidationData?.liquidationCRatio)
@@ -138,17 +241,34 @@ export function Overview() {
                         </StatusLabel>
                     )}
                 </Flex>
-                <StatusLabel status={Status.NEGATIVE}>
-                    {apy
-                        ? formatNumberWithStyle(apy, {
-                              minDecimals: 1,
-                              maxDecimals: 1,
-                              style: 'percent',
-                              scalingFactor: 100,
-                              suffixed: true,
-                          })
-                        : '--%'}{' '}
-                    Rewards APY
+                <StatusLabel
+                    status={
+                        userHaiVeloBoostData.myBoostedAPR === userHaiVeloBoostData.baseAPR
+                            ? Status.NO_DEBT
+                            : Status.POSITIVE
+                    }
+                >
+                    <span style={{ color: 'black' }}>
+                        {userHaiVeloBoostData.baseAPR
+                            ? formatNumberWithStyle(userHaiVeloBoostData.baseAPR, {
+                                  minDecimals: 1,
+                                  maxDecimals: 1,
+                                  style: 'percent',
+                                  suffixed: true,
+                              })
+                            : '--%'}
+                    </span>{' '}
+                    {userHaiVeloBoostData.myBoostedAPR !== userHaiVeloBoostData.baseAPR
+                        ? userHaiVeloBoostData.myBoostedAPR
+                            ? formatNumberWithStyle(userHaiVeloBoostData.myBoostedAPR, {
+                                  minDecimals: 1,
+                                  maxDecimals: 1,
+                                  style: 'percent',
+                                  suffixed: true,
+                              })
+                            : '--%'
+                        : ''}{' '}
+                    APR
                 </StatusLabel>
                 <Flex $justify="flex-end" $align="center" $gap={12} $fontSize="0.8em">
                     <Text>
@@ -250,6 +370,72 @@ export function Overview() {
                     {...progressProps}
                     fullWidth
                 />
+                {isHAIVELO ? (
+                    <>
+                        <OverviewStat
+                            value={formatNumberWithStyle(userHaiVeloBoostData.mystKiteShare, {
+                                minDecimals: 2,
+                                maxDecimals: 2,
+                                scalingFactor: 1,
+                                style: 'percent',
+                            })}
+                            label="My stKITE Share"
+                            button={
+                                userHaiVeloBoostData.myBoost === 2
+                                    ? undefined
+                                    : {
+                                          variant: 'yellowish',
+                                          text: 'Stake KITE',
+                                          onClick: () => {
+                                              window.location.href = '/stake'
+                                          },
+                                      }
+                            }
+                            tooltip={'Your staking share of the total stKITE supply'}
+                        />
+                        <OverviewStat
+                            value={`${formatNumberWithStyle(Number(userHaiVeloBoostData.myHaiVeloShare), {
+                                minDecimals: 0,
+                                maxDecimals: 2,
+                                scalingFactor: 1,
+                                style: 'percent',
+                            })}`}
+                            label="My haiVELO Share"
+                            simulatedValue={
+                                userHaiVeloBoostData.myHaiVeloShare !== userHaiVeloBoostData.myHaiVeloSimulatedShare
+                                    ? `${formatNumberWithStyle(Number(userHaiVeloBoostData.myHaiVeloSimulatedShare), {
+                                          minDecimals: 0,
+                                          maxDecimals: 2,
+                                          scalingFactor: 1,
+                                          style: 'percent',
+                                      })}`
+                                    : ''
+                            }
+                            tooltip={'The amount of  haiVELO you have in compare to the total haiVELO supply'}
+                        />
+                        <OverviewStat
+                            value={`${formatNumberWithStyle(Number(userHaiVeloBoostData.myBoost), {
+                                minDecimals: 0,
+                                maxDecimals: 2,
+                                scalingFactor: 1,
+                            })}x`}
+                            label="Boost"
+                            simulatedValue={
+                                userHaiVeloBoostData.myBoost !== userHaiVeloBoostData.simulatedBoostAfterDeposit
+                                    ? `${formatNumberWithStyle(
+                                          Number(userHaiVeloBoostData.simulatedBoostAfterDeposit),
+                                          {
+                                              minDecimals: 0,
+                                              maxDecimals: 2,
+                                              scalingFactor: 1,
+                                          }
+                                      )}x`
+                                    : ''
+                            }
+                            tooltip={'The amount of Boost you get for rewards over your haiVELO position'}
+                        />
+                    </>
+                ) : null}
             </Inner>
         </Container>
     )
@@ -303,6 +489,18 @@ const Inner = styled(Grid).attrs((props) => ({
         &:nth-child(5) {
             grid-column: 5 / -1;
         }
+        &:nth-child(6) {
+            grid-column: 1 / 7;
+        }
+        &:nth-child(7) {
+            grid-column: 1 / 3;
+        }
+        &:nth-child(8) {
+            grid-column: 3 / 5;
+        }
+        &:nth-child(9) {
+            grid-column: 5 / 7;
+        }
     }
     &::after {
         border-top: none;
@@ -311,10 +509,14 @@ const Inner = styled(Grid).attrs((props) => ({
 
     ${({ theme }) => theme.mediaWidth.upToMedium`
         & > * {
-            &:nth-child(1) {
+            &:nth-child(1), 
+            &:nth-child(2), 
+            &:nth-child(6) {
                 grid-column: 1 / -1;
             }
-            &:nth-child(2) {
+            &:nth-child(7),
+            &:nth-child(8),
+            &:nth-child(9) {
                 grid-column: 1 / -1;
             }
             padding: 12px;

--- a/src/containers/Vaults/Manage/OverviewStat.tsx
+++ b/src/containers/Vaults/Manage/OverviewStat.tsx
@@ -8,6 +8,7 @@ import { StatusLabel } from '~/components/StatusLabel'
 import { TokenArray } from '~/components/TokenArray'
 import { Tooltip } from '~/components/Tooltip'
 import { ProgressIndicator, ProgressIndicatorProps } from '~/components/ProgressIndicator'
+import { HaiButton, HaiButtonProps } from '~/styles/Button'
 
 type OverviewStatProps = {
     token?: TokenKey
@@ -23,6 +24,13 @@ type OverviewStatProps = {
     }
     simulatedValue?: string
     fullWidth?: boolean
+    button?: {
+        text: string
+        onClick: () => void
+        variant?: HaiButtonProps['$variant']
+        disabled?: boolean
+        size?: HaiButtonProps['$size']
+    }
 }
 export function OverviewStat({
     token,
@@ -35,6 +43,7 @@ export function OverviewStat({
     alert,
     simulatedValue,
     fullWidth = false,
+    button,
 }: OverviewStatProps) {
     return (
         <StatContainer $fullWidth={fullWidth}>
@@ -67,7 +76,7 @@ export function OverviewStat({
                     {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
                 </Flex>
             )}
-            <StatusContainer hidden={!simulatedValue && !alert}>
+            <ActionContainer hidden={!simulatedValue && !alert && !button}>
                 {!!alert && (
                     <StatusLabel status={alert.status} size={0.8}>
                         {alert.value || alert.status}
@@ -83,7 +92,17 @@ export function OverviewStat({
                         </Text>
                     </StatusLabel>
                 )}
-            </StatusContainer>
+                {!!button && (
+                    <HaiButton
+                        onClick={button.onClick}
+                        disabled={button.disabled}
+                        $variant={button.variant}
+                        $size={button.size}
+                    >
+                        {button.text}
+                    </HaiButton>
+                )}
+            </ActionContainer>
         </StatContainer>
     )
 }
@@ -96,6 +115,7 @@ export function OverviewProgressStat({
     alert,
     simulatedValue,
     fullWidth = false,
+    button,
     ...props
 }: OverviewProgressStatProps) {
     const isUpToSmall = useMediaQuery('upToSmall')
@@ -110,7 +130,7 @@ export function OverviewProgressStat({
                     </Text>
                     {!!tooltip && <Tooltip width="200px">{tooltip}</Tooltip>}
                 </CenteredFlex>
-                <StatusContainer hidden={!(simulatedValue && !isUpToSmall) && !alert}>
+                <ActionContainer hidden={!(simulatedValue && !isUpToSmall) && !alert && !button}>
                     {!!alert && (
                         <StatusLabel status={alert.status} size={0.8}>
                             {alert.value || alert.status}
@@ -126,7 +146,17 @@ export function OverviewProgressStat({
                             </Text>
                         </StatusLabel>
                     )}
-                </StatusContainer>
+                    {!!button && (
+                        <HaiButton
+                            onClick={button.onClick}
+                            disabled={button.disabled}
+                            $variant={button.variant}
+                            $size={button.size}
+                        >
+                            {button.text}
+                        </HaiButton>
+                    )}
+                </ActionContainer>
             </Flex>
             <ProgressIndicator {...props} />
             {simulatedValue && isUpToSmall && (
@@ -199,7 +229,7 @@ const ValueContainer = styled(Flex).attrs((props) => ({
     `} */
 `
 
-const StatusContainer = styled(Flex).attrs((props) => ({
+const ActionContainer = styled(Flex).attrs((props) => ({
     $justify: 'center',
     $align: 'center',
     $gap: 12,

--- a/src/containers/Vaults/Manage/index.tsx
+++ b/src/containers/Vaults/Manage/index.tsx
@@ -21,6 +21,10 @@ type ManageVaultProps = {
 export function ManageVault({ headerContent }: ManageVaultProps) {
     const { action, vault, updateForm } = useVault()
 
+    const isHAIVELO =
+        vault?.collateralName === 'HAIVELO' ||
+        new URLSearchParams(window.location.search).get('collateral') === 'HAIVELO'
+
     const { vault: vaultWithActivity } = useVaultById(vault?.id || '')
 
     const isUpToExtraSmall = useMediaQuery('upToExtraSmall')
@@ -41,7 +45,7 @@ export function ManageVault({ headerContent }: ManageVaultProps) {
                 <Header $removePadding={action === VaultAction.CREATE}>
                     {headerContent}
                     <CenteredFlex $gap={12}>
-                        <RewardsTokenArray tokens={['OP', 'KITE']} hideLabel={isUpToExtraSmall} />
+                        {isHAIVELO ? <RewardsTokenArray tokens={['HAI']} hideLabel={isUpToExtraSmall} /> : null}
                         <ManageDropdown $width={isUpToSmall ? '100%' : undefined} />
                     </CenteredFlex>
                 </Header>
@@ -50,7 +54,7 @@ export function ManageVault({ headerContent }: ManageVaultProps) {
             {tab === 0 || action === VaultAction.CREATE ? (
                 <ProxyPrompt>
                     <BodyGrid>
-                        <Overview />
+                        <Overview isHAIVELO={isHAIVELO} />
                         <VaultActions />
                     </BodyGrid>
                 </ProxyPrompt>

--- a/src/containers/Vaults/Stats.tsx
+++ b/src/containers/Vaults/Stats.tsx
@@ -4,12 +4,12 @@ import { formatNumberWithStyle } from '~/utils'
 import { useStoreActions, useStoreState } from '~/store'
 import { useEarnStrategies } from '~/hooks'
 
-import { HaiButton, Text } from '~/styles'
-import { RewardsTokenArray } from '~/components/TokenArray'
+// import { HaiButton, Text } from '~/styles'
+// import { RewardsTokenArray } from '~/components/TokenArray'
 import { Stats, type StatProps } from '~/components/Stats'
-import { Link } from '~/components/Link'
-import { Loader } from '~/components/Loader'
-import { RefreshCw } from 'react-feather'
+// import { Link } from '~/components/Link'
+// import { Loader } from '~/components/Loader'
+// import { RefreshCw } from 'react-feather'
 
 export function BorrowStats() {
     const {
@@ -85,7 +85,7 @@ export function BorrowStats() {
                 label: 'My Net Stability Fee',
                 tooltip: 'Weighted average stability fee of My Total Debt',
             },
-            {
+            /*{
                 header: formatNumberWithStyle(value ? apy / value : 0, {
                     maxDecimals: 1,
                     scalingFactor: 100,
@@ -114,9 +114,9 @@ export function BorrowStats() {
                     //     Claim
                     // </HaiButton>
                 ),
-            },
+            },*/
         ]
     }, [list, liquidationData, value, apy, popupsActions])
 
-    return <Stats stats={stats} columns="repeat(4, 1fr) 1.6fr" fun />
+    return <Stats stats={stats} /*columns="repeat(4, 1fr) 1.6fr"*/ fun />
 }

--- a/src/hooks/useBoost.tsx
+++ b/src/hooks/useBoost.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useCallback, useEffect } from 'react'
+import { useStoreActions } from '~/store'
+// import { useVault } from '~/providers/VaultProvider'
+import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { useAccount } from 'wagmi'
+import { formatUnits } from 'ethers/lib/utils'
+import { useLPData } from '~/providers/LPDataProvider'
+import { useVelodromePositions } from './useVelodrome'
+// import { formatNumberWithStyle } from '~/utils'
+import { useStaking } from '~/providers/StakingProvider'
+import { useHaiVeloData } from './useHaiVeloData'
+import { useAnalytics } from '~/providers/AnalyticsProvider'
+import {
+    calculateLPBoost,
+    calculateHaiVeloBoost,
+    combineBoostValues,
+    simulateNetBoost as simulateNetBoostService,
+    calculateBaseAPR,
+} from '~/services/boostService'
+
+export function useBoost() {
+    const { address } = useAccount()
+    // Use LP data from our enhanced model
+    const {
+        pool,
+        // userPositions,
+        userLPPositionValue,
+        userTotalLiquidity,
+        loading: lpDataLoading,
+        // NEW - Get boost data from LP data model
+        userLPBoostMap,
+        userKiteRatioMap,
+        userPositionsMap,
+    } = useLPData()
+    const { loading: positionsLoading } = useVelodromePositions()
+    const { prices: veloPrices } = useVelodromePrices()
+    const { stakingData, stakingStats, loading: stakingLoading } = useStaking()
+    const { userHaiVELODeposited, totalHaiVELODeposited } = useHaiVeloData()
+
+    const {
+        haiMarketPrice,
+        data: { tokenAnalyticsData },
+    } = useAnalytics()
+
+    // Get token price actions for updating the LP data model
+    const { updateTokenPrices, calculateAllPositionValues, calculateAllUserLiquidity } = useStoreActions(
+        (actions) => actions.lpDataModel
+    )
+
+    // Get HAI and WETH prices from analytics provider
+    const haiPrice = useMemo(() => parseFloat(haiMarketPrice.raw || '0'), [haiMarketPrice])
+
+    const wethPrice = useMemo(() => {
+        // Find WETH in the token analytics data
+        const wethData = tokenAnalyticsData.find((token) => token.symbol === 'WETH')
+        // Convert from wei to ETH (18 decimals)
+        return wethData ? parseFloat(formatUnits(wethData.currentPrice.toString(), 18)) : 0
+    }, [tokenAnalyticsData])
+
+    // Update token prices in the model when they change
+    useEffect(() => {
+        if (haiPrice && wethPrice) {
+            updateTokenPrices({
+                token0UsdPrice: haiPrice,
+                token1UsdPrice: wethPrice,
+            })
+
+            // Calculate position values for all users once prices are set
+            calculateAllPositionValues()
+
+            // Also calculate total liquidity (this doesn't need prices, but we can run it here)
+            calculateAllUserLiquidity()
+        }
+    }, [
+        haiPrice,
+        wethPrice,
+        updateTokenPrices,
+        userPositionsMap,
+        pool,
+        calculateAllPositionValues,
+        calculateAllUserLiquidity,
+    ])
+
+    // KITE staking data
+    const userKITEStaked = useMemo(() => {
+        return stakingLoading ? '0' : stakingData.stakedBalance
+    }, [stakingData, stakingLoading])
+
+    const totalKITEStaked = useMemo(() => {
+        return stakingLoading ? '0' : stakingStats.totalStaked
+    }, [stakingStats, stakingLoading])
+
+    // LP Position data - now using values from the model
+    const userLPPosition = userTotalLiquidity
+    const totalPoolLiquidity = pool?.liquidity || '0'
+    const calculatedUserLPPositionValue = userLPPositionValue
+
+    // Calculate haiVELO position value in USD using VELO price
+    const haiVeloPositionValue = useMemo(() => {
+        // Use the same price as VELO for haiVELO
+        const veloPrice = parseFloat(veloPrices?.VELO?.raw || '0')
+        const haiVeloAmount = parseFloat(userHaiVELODeposited || '0')
+
+        return (haiVeloAmount * veloPrice).toString()
+    }, [userHaiVELODeposited, veloPrices])
+
+    // Get LP boost from the model if available, or calculate it using boostService
+    const lpBoostValue = useMemo(() => {
+        if (address && userLPBoostMap[address.toLowerCase()]) {
+            return userLPBoostMap[address.toLowerCase()]
+        }
+
+        // Fallback to direct calculation if not available in the model
+        // Use the exact boostService function for consistency
+        const result = calculateLPBoost({
+            userStakingAmount: Number(userKITEStaked),
+            totalStakingAmount: Number(totalKITEStaked),
+            userLPPosition,
+            totalPoolLiquidity,
+        })
+
+        return result.lpBoost
+    }, [address, userLPBoostMap, userKITEStaked, totalKITEStaked, userLPPosition, totalPoolLiquidity])
+
+    // Get KITE ratio from the model if available, or calculate it
+    const kiteRatio = useMemo(() => {
+        if (address && userKiteRatioMap[address.toLowerCase()]) {
+            return userKiteRatioMap[address.toLowerCase()]
+        }
+
+        // Fallback to same calculation as in boostService
+        const totalStakingAmount = Number(totalKITEStaked)
+        return isNaN(totalStakingAmount) || totalStakingAmount === 0 ? 0 : Number(userKITEStaked) / totalStakingAmount
+    }, [address, userKiteRatioMap, userKITEStaked, totalKITEStaked])
+
+    // Calculate haiVELO boost values
+    const haiVeloBoostResult = useMemo(
+        () =>
+            calculateHaiVeloBoost({
+                userStakingAmount: Number(userKITEStaked),
+                totalStakingAmount: Number(totalKITEStaked),
+                userHaiVELODeposited,
+                totalHaiVELODeposited,
+            }),
+        [userKITEStaked, totalKITEStaked, userHaiVELODeposited, totalHaiVELODeposited]
+    )
+
+    // Combine the boost values
+    const combinedBoostResult = useMemo(
+        () =>
+            combineBoostValues({
+                lpBoost: lpBoostValue,
+                haiVeloBoost: haiVeloBoostResult.haiVeloBoost,
+                userLPPositionValue: calculatedUserLPPositionValue,
+                haiVeloPositionValue,
+            }),
+        [lpBoostValue, haiVeloBoostResult.haiVeloBoost, calculatedUserLPPositionValue, haiVeloPositionValue]
+    )
+
+    // Reuse the simulation function from the service
+    const simulateNetBoost = useCallback(
+        (userAfterStakingAmount: number, totalAfterStakingAmount: number) => {
+            return simulateNetBoostService({
+                userAfterStakingAmount,
+                totalAfterStakingAmount,
+                userLPPosition,
+                totalPoolLiquidity,
+                userLPPositionValue: calculatedUserLPPositionValue,
+                userHaiVELODeposited,
+                totalHaiVELODeposited,
+                haiVeloPositionValue,
+            })
+        },
+        [
+            userLPPosition,
+            totalPoolLiquidity,
+            calculatedUserLPPositionValue,
+            userHaiVELODeposited,
+            totalHaiVELODeposited,
+            haiVeloPositionValue,
+        ]
+    )
+
+    const totalDailyRewardsInUSD = 0.1
+    const baseAPR = useMemo(
+        () =>
+            calculateBaseAPR({
+                totalDailyRewardsInUSD,
+                haiVeloPositionValue,
+                userLPPositionValue: calculatedUserLPPositionValue,
+            }),
+        [totalDailyRewardsInUSD, haiVeloPositionValue, calculatedUserLPPositionValue]
+    )
+
+    return {
+        // HaiVELO data
+        userHaiVELODeposited,
+        totalHaiVELODeposited,
+        haiVeloPositionValue,
+
+        // KITE staking data
+        userKITEStaked,
+        totalKITEStaked,
+
+        // LP Position data
+        userLPPosition,
+        totalPoolLiquidity,
+        userLPPositionValue: calculatedUserLPPositionValue,
+
+        // Boost data from the LP data model
+        kiteRatio,
+        hvBoost: haiVeloBoostResult.haiVeloBoost,
+        lpBoostValue,
+        userTotalValue: Number(calculatedUserLPPositionValue) + Number(haiVeloPositionValue),
+        netBoostValue: combinedBoostResult.netBoost,
+
+        simulateNetBoost,
+
+        baseAPR,
+
+        // Loading state
+        loading: lpDataLoading || positionsLoading || stakingLoading,
+    }
+}

--- a/src/hooks/useEarnStrategies.tsx
+++ b/src/hooks/useEarnStrategies.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { formatUnits } from 'ethers/lib/utils'
 import { useQuery } from '@apollo/client'
 import { useAccount } from 'wagmi'
@@ -21,6 +21,9 @@ import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
 import { useVelodrome, useVelodromePositions } from './useVelodrome'
 import { useBalance, useMyVaults, useCollateralStats } from '~/hooks'
 import { useAnalytics } from '~/providers/AnalyticsProvider'
+// import { useLPData } from '~/providers/LPDataProvider'
+import { useHaiVeloData } from './useHaiVeloData'
+import { calculateHaiVeloBoost } from '~/services/boostService'
 
 const sortableHeaders: SortableHeader[] = [
     { label: 'Asset / Asset Pair' },
@@ -30,11 +33,15 @@ const sortableHeaders: SortableHeader[] = [
         tooltip: `Value participating in campaign`,
     },
     {
-        label: 'My Position',
+        label: 'Position',
         tooltip: `Your value participating in the campaign`,
     },
     {
-        label: 'Rewards APY',
+        label: 'Boost',
+        tooltip: `Amount of boost you will receive based on your participation and staked kite`,
+    },
+    {
+        label: 'APR',
         tooltip: `Variable based upon participation and value of campaign emissions`,
     },
 ]
@@ -43,10 +50,27 @@ export function useEarnStrategies() {
     const {
         connectWalletModel: { tokensData },
         vaultModel: { list, liquidationData },
+        lpDataModel: { userLPBoostMap, userPositionValuesMap },
+        stakingModel: { usersStakingData, totalStaked },
     } = useStoreState((state) => state)
 
+    // Check if store data is loaded
+    const isStoreDataLoaded = !!tokensData && !!liquidationData && !!list
+
+    const { userCollateralMapping } = useHaiVeloData()
+    const isHaiVeloDataLoaded = !!userCollateralMapping
+
+    // const haiPrice = parseFloat(liquidationData?.currentRedemptionPrice || '1')
+
     const { address } = useAccount()
-    const { prices: veloPrices } = useVelodromePrices()
+    const { prices: veloPrices, loading: veloPricesLoading } = useVelodromePrices()
+
+    const HAI_WETH_DAILY_REWARDS = 100
+
+    const HAI_VELO_DAILY_REWARDS = useMemo(() => {
+        if (!veloPrices || !veloPrices.VELO.raw || !veloPrices.HAI.raw) return 780
+        return (35 * parseFloat(veloPrices.HAI.raw)) / parseFloat(veloPrices.VELO.raw)
+    }, [veloPrices])
 
     const { data, loading, error } = useQuery<{ collateralTypes: QueryCollateralType[] }>(ALL_COLLATERAL_TYPES_QUERY)
 
@@ -67,9 +91,11 @@ export function useEarnStrategies() {
         }
     )
     const { data: veloData, loading: veloLoading, error: veloError } = useVelodrome()
-    const { data: veloPositions } = useVelodromePositions()
+    const { data: veloPositions, loading: veloPositionsLoading } = useVelodromePositions()
 
     const prices = useMemo(() => {
+        if (!liquidationData || !veloPrices) return null
+
         return {
             HAI: parseFloat(liquidationData?.currentRedemptionPrice || '0'),
             KITE: parseFloat(veloPrices?.KITE.raw || '0'),
@@ -79,9 +105,13 @@ export function useEarnStrategies() {
         }
     }, [liquidationData?.currentRedemptionPrice, liquidationData?.collateralLiquidationData, veloPrices])
 
+    // const defaultPrices = { HAI: 0, KITE: 0, VELO: 0, OP: 0, WETH: 0 }
+
     const vaultStrategies = useMemo(() => {
+        if (!data?.collateralTypes || !prices) return []
+
         return (
-            data?.collateralTypes
+            data.collateralTypes
                 .filter((cType) =>
                     Object.values(REWARDS.vaults[cType.id as keyof typeof REWARDS.vaults] || {}).some((a) => a != 0)
                 )
@@ -97,7 +127,7 @@ export function useEarnStrategies() {
                         rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })),
                         tvl: cType.debtAmount,
                         strategyType: 'borrow',
-                        apy,
+                        apr: apy,
                         userPosition: list
                             .reduce((total, { totalDebt, collateralName }) => {
                                 if (collateralName !== symbol) return total
@@ -110,8 +140,49 @@ export function useEarnStrategies() {
     }, [data?.collateralTypes, prices, list, tokenAssets])
 
     const uniStrategies = useMemo(() => {
-        if (!uniData?.liquidityPools.length) return []
+        if (!uniData?.liquidityPools.length || !prices) return []
         const temp: Strategy[] = []
+
+        const calculateBoostAPR = () => {
+            const calculateTotalBoostedValueParticipating = () => {
+                return Object.entries(userPositionValuesMap).reduce((acc, [address, value]) => {
+                    return acc + value * userLPBoostMap[address]
+                }, 0)
+            }
+
+            const totalBoostedValueParticipating = calculateTotalBoostedValueParticipating()
+
+            const baseAPR = totalBoostedValueParticipating
+                ? (HAI_WETH_DAILY_REWARDS / totalBoostedValueParticipating) * 365 * 100
+                : 0
+
+            const myBoost = address ? userLPBoostMap[address.toLowerCase()] : 1
+
+            const myValueParticipating = address ? userPositionValuesMap[address.toLowerCase()] : 0
+
+            const myBoostedValueParticipating = myValueParticipating * myBoost
+
+            const myBoostedShare = totalBoostedValueParticipating
+                ? myBoostedValueParticipating / totalBoostedValueParticipating
+                : 0
+
+            // myBoost * baseAPR
+
+            const myBoostedAPR = myBoost * baseAPR //((myBoostedShare * HAI_WETH_DAILY_REWARDS) / myValueParticipating) * 365 * 100
+
+            return {
+                totalBoostedValueParticipating,
+                baseAPR,
+                myBoost,
+                myValueParticipating,
+                myBoostedValueParticipating,
+                myBoostedShare,
+                myBoostedAPR,
+                userLPBoostMap,
+                userPositionValuesMap,
+            }
+        }
+
         for (const pool of uniData.liquidityPools) {
             const rewards = REWARDS.uniswap[pool.id.toLowerCase()]
             if (!rewards) continue // sanity check
@@ -120,11 +191,15 @@ export function useEarnStrategies() {
                 parseFloat(formatUnits(pool.inputTokenBalances[0], 18)) * prices.HAI +
                 parseFloat(formatUnits(pool.inputTokenBalances[1], 18)) * prices.WETH
             const apy = calculateAPY(tvl, prices, rewards)
+            const apr = calculateAPR(tvl, prices, rewards)
+            const boostAPRData = calculateBoostAPR()
             temp.push({
                 pair: pool.inputTokens.map((token) => token.symbol) as any,
                 rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })) as any,
                 tvl: tvl.toString(),
                 apy,
+                apr,
+                boostAPR: boostAPRData,
                 userPosition: (pool.positions || [])
                     .reduce((total, { cumulativeDepositTokenAmounts, cumulativeWithdrawTokenAmounts }) => {
                         const posHai =
@@ -139,17 +214,17 @@ export function useEarnStrategies() {
                 earnPlatform: 'uniswap',
                 earnAddress: pool.id,
                 strategyType: 'farm',
-                earnLink: `https://info.uniswap.org/#/optimism/pools/${pool.id}`,
+                earnLink: `https://app.uniswap.org/explore/pools/optimism/${pool.id}`,
             } as Strategy)
         }
         return temp
-    }, [uniData?.liquidityPools, prices])
+    }, [uniData?.liquidityPools, prices, userLPBoostMap, userPositionValuesMap])
 
     const veloStrategies = useMemo(() => {
-        if (!veloPrices || !veloData) return []
+        if (!veloPrices || !veloData || !prices) return []
         const temp: Strategy[] = []
         // Filter out SAIL
-        for (const pool of veloData.filter((p) => p.address != '0xB5cD4bD4bdB5C97020FBE192258e6F08333990E2')) {
+        for (const pool of veloData.filter((p) => p.address === '0xf2d3941b6E1cbD3616061E556Eb06986147715d1')) {
             const rewards = REWARDS.velodrome[pool.address.toLowerCase()]
             if (!rewards) continue // filter out any extra pools that may be fetched
 
@@ -171,13 +246,14 @@ export function useEarnStrategies() {
 
             const tvl = tvl0 + tvl1
             const veloAPR = (365 * parseFloat(formatUnits(pool.emissions, pool.decimals)) * prices.VELO * 86400) / tvl
-            const apy = veloAPR === Infinity ? 0 : Math.pow(1 + veloAPR / 12, 12) - 1
+
+            // const apy = veloAPR === Infinity ? 0 : Math.pow(1 + veloAPR / 12, 12) - 1
 
             temp.push({
                 pair: [token0, token1] as any,
                 rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })) as any,
                 tvl: tvl.toString(),
-                apy,
+                apr: veloAPR,
                 userPosition: (veloPositions || [])
                     .reduce((total, position) => {
                         if (!stringsExistAndAreEqual(position.lp, pool.address)) return total
@@ -221,36 +297,169 @@ export function useEarnStrategies() {
         )
     }, [myVaults])
 
-    const specialStrategies = [
-        {
-            pair: ['HAI'],
-            rewards: [],
-            tvl: erc20Supply.raw,
-            apy: rRateApy,
-            userPosition: haiBalance?.raw,
-            strategyType: 'hold',
-        },
-        {
-            pair: ['HAIVELO'],
-            rewards: [],
-            tvl: haiVeloTVL,
-            apy: '0',
-            userPosition: myHaiVeloParticipation,
-            strategyType: 'deposit',
-        },
-    ]
+    const calculateHaiVeloBoostAPR = useCallback(() => {
+        if (!userCollateralMapping || !usersStakingData) return null
+
+        const totalHaiVeloDeposited = Object.values(userCollateralMapping).reduce((acc, value) => {
+            return acc + Number(value)
+        }, 0)
+
+        const totalStakedAmount = Object.values(usersStakingData).reduce((acc, value) => {
+            return acc + Number(value?.stakedBalance)
+        }, 0)
+
+        const userHaiVeloBoostMap: Record<string, number> = Object.entries(userCollateralMapping).reduce(
+            (acc, [address, value]) => {
+                if (!usersStakingData[address]) return { ...acc, [address]: 1 }
+
+                return {
+                    ...acc,
+                    [address]: calculateHaiVeloBoost({
+                        userStakingAmount: Number(usersStakingData[address]?.stakedBalance),
+                        totalStakingAmount: Number(totalStakedAmount),
+                        userHaiVELODeposited: Number(value),
+                        totalHaiVELODeposited: Number(totalHaiVeloDeposited),
+                    }).haiVeloBoost,
+                }
+            },
+            {}
+        )
+
+        const calculateTotalBoostedValueParticipating = () => {
+            return Object.entries(userCollateralMapping).reduce((acc, [address, value]) => {
+                return acc + Number(value) * userHaiVeloBoostMap[address]
+            }, 0)
+        }
+
+        const totalBoostedValueParticipating = calculateTotalBoostedValueParticipating()
+
+        const baseAPR = totalBoostedValueParticipating
+            ? (HAI_VELO_DAILY_REWARDS / totalBoostedValueParticipating) * 365 * 100
+            : 0
+
+        const myBoost = address ? userHaiVeloBoostMap[address.toLowerCase()] : 1
+
+        const myValueParticipating = address ? userCollateralMapping[address.toLowerCase()] : 0
+
+        const myBoostedValueParticipating = Number(myValueParticipating) * myBoost
+
+        const myBoostedShare = totalBoostedValueParticipating
+            ? myBoostedValueParticipating / totalBoostedValueParticipating
+            : 0
+
+        // myBoost * baseAPR
+
+        const myBoostedAPR = myBoost * baseAPR //((myBoostedShare * HAI_VELO_DAILY_REWARDS) / myValueParticipating) * 365 * 100
+
+        return {
+            totalBoostedValueParticipating,
+            baseAPR,
+            myBoost,
+            myValueParticipating,
+            myBoostedValueParticipating,
+            myBoostedShare,
+            myBoostedAPR,
+            userLPBoostMap,
+            userPositionValuesMap,
+        }
+    }, [userCollateralMapping, userLPBoostMap, address, usersStakingData, totalStaked, HAI_VELO_DAILY_REWARDS])
+
+    const specialStrategies = useMemo(() => {
+        if (!prices) return []
+
+        const haiVeloBoostData = calculateHaiVeloBoostAPR()
+
+        return [
+            {
+                pair: ['HAI'],
+                rewards: [],
+                tvl: erc20Supply.raw,
+                apr: rRateApy,
+                userPosition: haiBalance?.raw,
+                strategyType: 'hold',
+            },
+            {
+                pair: ['HAIVELO'],
+                rewards: [],
+                tvl: haiVeloTVL,
+                apr: '0',
+                boostAPR: haiVeloBoostData,
+                userPosition: myHaiVeloParticipation,
+                strategyType: 'deposit',
+            },
+        ]
+    }, [
+        prices,
+        erc20Supply.raw,
+        rRateApy,
+        haiBalance?.raw,
+        haiVeloTVL,
+        myHaiVeloParticipation,
+        calculateHaiVeloBoostAPR,
+    ])
+
+    const isLoading =
+        loading ||
+        uniLoading ||
+        veloLoading ||
+        veloPositionsLoading ||
+        veloPricesLoading ||
+        !isStoreDataLoaded ||
+        !isHaiVeloDataLoaded ||
+        !prices
 
     const strategies = useMemo(() => {
+        if (isLoading) return []
         return [...specialStrategies, ...vaultStrategies, ...uniStrategies, ...veloStrategies]
-    }, [specialStrategies, vaultStrategies, uniStrategies, veloStrategies])
+    }, [isLoading, specialStrategies, vaultStrategies, uniStrategies, veloStrategies])
+
+    const averageAPR = useMemo(() => {
+        if (isLoading || strategies.length === 0) {
+            return {
+                totalPosition: 0,
+                averageWeightedAPR: 0,
+                averageWeightedBoostedAPR: 0,
+                effectiveStrategiesAPR: [],
+            }
+        }
+
+        const totalPosition = strategies.reduce((acc, strategy) => {
+            return acc + Number(strategy.userPosition)
+        }, 0)
+
+        const effectiveStrategiesAPR = strategies.map((strategy) => {
+            return {
+                apr: strategy.boostAPR ? Number(strategy.boostAPR.baseAPR) : Number(strategy.apr),
+                boostedApr: strategy.boostAPR ? Number(strategy.boostAPR.myBoostedAPR) : 0,
+            }
+        })
+
+        const averageWeightedAPR = strategies.reduce((acc, strategy, i) => {
+            const strategyAPR = effectiveStrategiesAPR[i]
+            return acc + (Number(strategy.userPosition) / totalPosition) * (strategyAPR ? strategyAPR.apr : 0)
+        }, 0)
+
+        const averageWeightedBoostedAPR = strategies.reduce((acc, strategy, i) => {
+            const strategyAPR = effectiveStrategiesAPR[i]
+            return acc + (Number(strategy.userPosition) / totalPosition) * (strategyAPR ? strategyAPR.boostedApr : 0)
+        }, 0)
+
+        return {
+            totalPosition,
+            averageWeightedAPR,
+            averageWeightedBoostedAPR,
+            effectiveStrategiesAPR,
+        }
+    }, [isLoading, strategies, userCollateralMapping, usersStakingData, totalStaked])
 
     const [filterEmpty, setFilterEmpty] = useState(false)
 
     const filteredRows = useMemo(() => {
+        if (isLoading) return []
         if (!filterEmpty) return strategies
 
         return strategies.filter(({ userPosition }) => !!userPosition && userPosition !== '0')
-    }, [strategies, filterEmpty])
+    }, [strategies, filterEmpty, isLoading])
 
     const [sorting, setSorting] = useState<Sorting>({
         key: 'My Position',
@@ -258,6 +467,8 @@ export function useEarnStrategies() {
     })
 
     const sortedRows = useMemo(() => {
+        if (isLoading) return []
+
         switch (sorting.key) {
             case 'Asset / Asset Pair':
                 return arrayToSorted(filteredRows, {
@@ -278,9 +489,9 @@ export function useEarnStrategies() {
                     type: 'parseFloat',
                     checkValueExists: true,
                 })
-            case 'Rewards APY':
+            case 'Rewards APR':
                 return arrayToSorted(filteredRows, {
-                    getProperty: (row) => row.apy,
+                    getProperty: (row) => row.apr,
                     dir: sorting.dir,
                     type: 'numerical',
                 })
@@ -293,13 +504,14 @@ export function useEarnStrategies() {
                     checkValueExists: true,
                 })
         }
-    }, [filteredRows, sorting])
+    }, [filteredRows, sorting, isLoading])
 
     return {
         headers: sortableHeaders,
+        averageAPR,
         rows: sortedRows,
         rowsUnmodified: strategies,
-        loading: loading || uniLoading || veloLoading,
+        loading: isLoading,
         error: error?.message,
         uniError: uniError?.message,
         veloError,
@@ -310,12 +522,25 @@ export function useEarnStrategies() {
     }
 }
 
-const calculateAPY = (
+const calculateAPR = (
     tvl: number,
-    prices: { KITE: number; OP: number },
+    prices: { KITE: number; OP: number } | null | undefined,
     rewards: { KITE: number; OP: number } = REWARDS.default
 ) => {
-    if (!tvl) return 0
+    if (!tvl || !prices) return 0
+    if (!prices.KITE || !prices.OP) return 0
+
+    // ((kite-daily-emission * kite-price + op-daily-emission * op-price) * 365) / (hai-debt-per-collateral * hai-redemption-price)
+    const nominal = (365 * (rewards.KITE * prices.KITE + rewards.OP * prices.OP)) / tvl
+    return nominal
+}
+
+const calculateAPY = (
+    tvl: number,
+    prices: { KITE: number; OP: number } | null | undefined,
+    rewards: { KITE: number; OP: number } = REWARDS.default
+) => {
+    if (!tvl || !prices) return 0
     if (!prices.KITE || !prices.OP) return 0
 
     // ((kite-daily-emission * kite-price + op-daily-emission * op-price) * 365) / (hai-debt-per-collateral * hai-redemption-price)

--- a/src/hooks/useHaiVeloData.tsx
+++ b/src/hooks/useHaiVeloData.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from 'react'
+import { ApolloError, useQuery, gql } from '@apollo/client'
+// import { formatSummaryValue } from '~/utils'
+import { useAccount } from 'wagmi'
+
+// Define the GraphQL query to fetch HAIVELO collateral data
+const HAIVELO_COLLATERAL_QUERY = gql`
+    query GetTotalCollateralByType($collateralTypeId: ID!) {
+        collateralType(id: $collateralTypeId) {
+            id
+            totalCollateral
+        }
+    }
+`
+
+// Query to get user safes by collateral type
+const USER_SAFES_QUERY = gql`
+    query GetSafesByCollateralTypeAndOwner($collateralTypeId: ID!, $ownerId: ID, $limit: Int = 1000) {
+        safes(
+            where: { collateralType_: { id: $collateralTypeId }, owner_: { id: $ownerId } }
+            orderBy: collateral
+            orderDirection: desc
+            first: $limit
+        ) {
+            id
+            safeId
+            collateral
+            debt
+            cRatio
+            safeHandler
+            owner {
+                id
+                address
+            }
+            createdAt
+            modifiedAt
+        }
+    }
+`
+
+// Query to get all safes by collateral type
+const ALL_SAFES_QUERY = gql`
+    query GetAllSafesByCollateralType($collateralTypeId: ID!, $limit: Int = 1000) {
+        safes(
+            where: { collateralType_: { id: $collateralTypeId } }
+            orderBy: collateral
+            orderDirection: desc
+            first: $limit
+        ) {
+            id
+            safeId
+            collateral
+            debt
+            cRatio
+            safeHandler
+            owner {
+                id
+                address
+            }
+            createdAt
+            modifiedAt
+        }
+    }
+`
+
+// Type definitions for query response
+export type HaiVeloCollateralData = {
+    collateralType: {
+        id: string
+        totalCollateral: string
+    }
+}
+
+// Type for user safes
+export type UserSafe = {
+    id: string
+    safeId: string
+    collateral: string
+    debt: string
+    cRatio: string
+    safeHandler: string
+    owner: {
+        id: string
+        address: string
+    }
+    createdAt: string
+    modifiedAt: string
+}
+
+export type UserSafesData = {
+    safes: UserSafe[]
+}
+
+export type AllSafesData = {
+    safes: UserSafe[]
+}
+
+// Type for user collateral mapping
+export type UserCollateralMapping = {
+    [userAddress: string]: string
+}
+
+export type HaiVeloData = {
+    loading: boolean
+    error?: ApolloError
+    data?: HaiVeloCollateralData
+    totalHaiVELODeposited: string
+    userHaiVELODeposited: string
+    userCollateralMapping: UserCollateralMapping
+}
+
+export function useHaiVeloData(): HaiVeloData {
+    const { address } = useAccount()
+    //const address = '0x328cace41eadf6df6e693b8e4810bf97aac4f5ee'
+
+    // Query the GraphQL API for HAIVELO collateral data
+    const { data, loading, error } = useQuery<HaiVeloCollateralData>(HAIVELO_COLLATERAL_QUERY, {
+        variables: {
+            collateralTypeId: 'HAIVELO',
+        },
+        fetchPolicy: 'cache-and-network',
+    })
+
+    // Query user's HAIVELO safes if address is available
+    const { data: userSafesData, loading: userSafesLoading } = useQuery<UserSafesData>(USER_SAFES_QUERY, {
+        variables: {
+            collateralTypeId: 'HAIVELO',
+            ownerId: address?.toLowerCase() || '',
+        },
+        skip: !address,
+        fetchPolicy: 'cache-and-network',
+    })
+
+    // Query all HAIVELO safes
+    const { data: allSafesData, loading: allSafesLoading } = useQuery<AllSafesData>(ALL_SAFES_QUERY, {
+        variables: {
+            collateralTypeId: 'HAIVELO',
+        },
+        fetchPolicy: 'cache-and-network',
+    })
+
+    // Format and extract the data using useMemo to prevent unnecessary recalculations
+    const formattedData = useMemo(() => {
+        if (!data) {
+            return {
+                totalHaiVELODeposited: '0',
+                userHaiVELODeposited: '0',
+                userCollateralMapping: {},
+            }
+        }
+
+        // Extract the total collateral amount
+        const { totalCollateral } = data.collateralType
+
+        // Format the values for display
+        // const formattedTotal = formatSummaryValue(totalCollateral, {
+        //     maxDecimals: 2,
+        // }) || { formatted: '0' }
+
+        // Calculate user's total HAIVELO deposits if user data is available
+        let userDeposited = '0'
+        if (userSafesData?.safes && userSafesData.safes.length > 0) {
+            // Sum up all collateral from user's safes
+            const totalUserCollateral = userSafesData.safes
+                .reduce((total, safe) => total + parseFloat(safe.collateral), 0)
+                .toString()
+
+            // // Format user's total
+            // const formattedUserTotal = formatSummaryValue(totalUserCollateral, {
+            //   maxDecimals: 2
+            // }) || { formatted: '0' }
+
+            // userDeposited = formattedUserTotal.formatted
+            userDeposited = totalUserCollateral
+        }
+
+        // Create mapping of user addresses to their collateral amounts
+        const userCollateralMapping: UserCollateralMapping = {}
+
+        if (allSafesData?.safes && allSafesData.safes.length > 0) {
+            // Group safes by owner address and sum their collateral
+            allSafesData.safes.forEach((safe) => {
+                const ownerAddress = safe.owner.address.toLowerCase()
+                const collateralAmount = parseFloat(safe.collateral)
+
+                if (userCollateralMapping[ownerAddress]) {
+                    // Add to existing collateral for this user
+                    userCollateralMapping[ownerAddress] = (
+                        parseFloat(userCollateralMapping[ownerAddress]) + collateralAmount
+                    ).toString()
+                } else {
+                    // First safe for this user
+                    userCollateralMapping[ownerAddress] = collateralAmount.toString()
+                }
+            })
+        }
+
+        return {
+            totalHaiVELODeposited: totalCollateral || '0',
+            userHaiVELODeposited: userDeposited || '0',
+            userCollateralMapping,
+        }
+    }, [data, userSafesData, allSafesData])
+
+    // Return the data object with loading and error states
+    return {
+        loading: loading || userSafesLoading || allSafesLoading,
+        error,
+        data,
+        ...formattedData,
+    }
+}

--- a/src/hooks/useStakeActivities.tsx
+++ b/src/hooks/useStakeActivities.tsx
@@ -1,0 +1,269 @@
+import { useMemo, useState } from 'react'
+import { formatUnits } from 'ethers/lib/utils'
+import { useQuery } from '@apollo/client'
+import { useAccount } from 'wagmi'
+
+import type { SortableHeader, Sorting, Strategy } from '~/types'
+import {
+    ALL_COLLATERAL_TYPES_QUERY,
+    OPTIMISM_UNISWAP_POOL_QUERY,
+    OPTIMISM_UNISWAP_POOL_WITH_POSITION_QUERY,
+    REWARDS,
+    type QueryCollateralType,
+    arrayToSorted,
+    tokenAssets,
+    QueryLiquidityPoolWithPositions,
+    uniClient,
+    stringsExistAndAreEqual,
+} from '~/utils'
+import { useStoreState } from '~/store'
+import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { useVelodrome, useVelodromePositions } from './useVelodrome'
+
+const sortableHeaders: SortableHeader[] = [
+    { label: 'Action', tooltip: 'information about the action' },
+    { label: 'Balance Change' },
+    {
+        label: 'Boost Change',
+    },
+    {
+        label: 'Timestamp',
+    },
+    {
+        label: 'Transaction',
+    },
+]
+
+export function useEarnStrategies() {
+    const {
+        connectWalletModel: { tokensData },
+        vaultModel: { list, liquidationData },
+    } = useStoreState((state) => state)
+
+    const { address } = useAccount()
+    const { prices: veloPrices } = useVelodromePrices()
+
+    const { data, loading, error } = useQuery<{ collateralTypes: QueryCollateralType[] }>(ALL_COLLATERAL_TYPES_QUERY)
+    const {
+        data: uniData,
+        loading: uniLoading,
+        error: uniError,
+    } = useQuery<{ liquidityPools: QueryLiquidityPoolWithPositions[] }>(
+        address ? OPTIMISM_UNISWAP_POOL_WITH_POSITION_QUERY : OPTIMISM_UNISWAP_POOL_QUERY,
+        {
+            client: uniClient,
+            variables: {
+                ids: Object.keys(REWARDS.uniswap),
+                address,
+            },
+        }
+    )
+    const { data: veloData, loading: veloLoading, error: veloError } = useVelodrome()
+    const { data: veloPositions } = useVelodromePositions()
+
+    const prices = useMemo(() => {
+        return {
+            HAI: parseFloat(liquidationData?.currentRedemptionPrice || '0'),
+            KITE: parseFloat(veloPrices?.KITE.raw || '0'),
+            VELO: parseFloat(veloPrices?.VELO.raw || '0'),
+            OP: parseFloat(liquidationData?.collateralLiquidationData['OP']?.currentPrice.value || '0'),
+            WETH: parseFloat(liquidationData?.collateralLiquidationData['WETH']?.currentPrice.value || '0'),
+        }
+    }, [liquidationData?.currentRedemptionPrice, liquidationData?.collateralLiquidationData, veloPrices])
+
+    const vaultStrategies = useMemo(() => {
+        return (
+            data?.collateralTypes
+                .filter((cType) =>
+                    Object.values(REWARDS.vaults[cType.id as keyof typeof REWARDS.vaults] || {}).some((a) => a != 0)
+                )
+                .map((cType) => {
+                    const { symbol } =
+                        tokenAssets[cType.id] ||
+                        Object.values(tokenAssets).find(({ name }) => name.toLowerCase() === cType.id.toLowerCase()) ||
+                        {}
+                    const rewards = REWARDS.vaults[symbol as keyof typeof REWARDS.vaults] || REWARDS.default
+                    const apy = calculateAPY(parseFloat(cType.debtAmount) * prices.HAI, prices, rewards)
+                    return {
+                        pair: [symbol || 'HAI'],
+                        rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })),
+                        tvl: cType.debtAmount,
+                        apy,
+                        userPosition: list
+                            .reduce((total, { totalDebt, collateralName }) => {
+                                if (collateralName !== symbol) return total
+                                return total + parseFloat(totalDebt)
+                            }, 0)
+                            .toString(),
+                    } as Strategy
+                }) || []
+        )
+    }, [data?.collateralTypes, prices, list, tokenAssets])
+
+    const uniStrategies = useMemo(() => {
+        if (!uniData?.liquidityPools.length) return []
+        const temp: Strategy[] = []
+        for (const pool of uniData.liquidityPools) {
+            const rewards = REWARDS.uniswap[pool.id.toLowerCase()]
+            if (!rewards) continue // sanity check
+
+            const tvl =
+                parseFloat(formatUnits(pool.inputTokenBalances[0], 18)) * prices.HAI +
+                parseFloat(formatUnits(pool.inputTokenBalances[1], 18)) * prices.WETH
+            const apy = calculateAPY(tvl, prices, rewards)
+            temp.push({
+                pair: pool.inputTokens.map((token) => token.symbol) as any,
+                rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })) as any,
+                tvl: tvl.toString(),
+                apy,
+                userPosition: (pool.positions || [])
+                    .reduce((total, { cumulativeDepositTokenAmounts, cumulativeWithdrawTokenAmounts }) => {
+                        const posHai =
+                            parseFloat(formatUnits(cumulativeDepositTokenAmounts[0], 18)) -
+                            parseFloat(formatUnits(cumulativeWithdrawTokenAmounts[0], 18))
+                        const posETH =
+                            parseFloat(formatUnits(cumulativeDepositTokenAmounts[1], 18)) -
+                            parseFloat(formatUnits(cumulativeWithdrawTokenAmounts[1], 18))
+                        return total + (posHai * prices.HAI + posETH * prices.WETH)
+                    }, 0)
+                    .toString(),
+                earnPlatform: 'uniswap',
+                earnAddress: pool.id,
+                earnLink: `https://info.uniswap.org/#/optimism/pools/${pool.id}`,
+            } as Strategy)
+        }
+        return temp
+    }, [uniData?.liquidityPools, prices])
+
+    const veloStrategies = useMemo(() => {
+        if (!veloPrices || !veloData) return []
+        const temp: Strategy[] = []
+        for (const pool of veloData) {
+            const rewards = REWARDS.velodrome[pool.address.toLowerCase()]
+            if (!rewards) continue // filter out any extra pools that may be fetched
+
+            // daily_rewards = Lp. emissions * velo price * 86400
+            // tv1 =(Lp. reserve * token0 _price) + (Lp.reservel * token1 _price)
+            // staked_tvl = tvl * (Lp. gauge_total_supply / Lp.total_supply)
+            // apr = (daily_rewards / staked_tv1) * 365
+            const token0 =
+                Object.values(tokensData).find(({ address }) => stringsExistAndAreEqual(address, pool.token0))
+                    ?.symbol || pool.tokenPair[0]
+            const price0 = parseFloat((veloPrices as any)[token0]?.raw || (prices as any)[token0]?.toString() || '1')
+            const tvl0 = parseFloat(formatUnits(pool.staked0, pool.decimals)) * price0
+
+            const token1 =
+                Object.values(tokensData).find(({ address }) => stringsExistAndAreEqual(address, pool.token1))
+                    ?.symbol || pool.tokenPair[1]
+            const price1 = parseFloat((veloPrices as any)[token1]?.raw || (prices as any)[token1]?.toString() || '1')
+            const tvl1 = parseFloat(formatUnits(pool.staked1, pool.decimals)) * price1
+
+            const tvl = tvl0 + tvl1
+            const veloAPR = (365 * parseFloat(formatUnits(pool.emissions, pool.decimals)) * prices.VELO * 86400) / tvl
+            const apy = veloAPR === Infinity ? 0 : Math.pow(1 + veloAPR / 12, 12) - 1
+
+            temp.push({
+                pair: [token0, token1] as any,
+                rewards: Object.entries(rewards).map(([token, emission]) => ({ token, emission })) as any,
+                tvl: tvl.toString(),
+                apy,
+                userPosition: (veloPositions || [])
+                    .reduce((total, position) => {
+                        if (!stringsExistAndAreEqual(position.lp, pool.address)) return total
+                        return (
+                            total +
+                            parseFloat(formatUnits(position.staked0, pool.decimals)) * price0 +
+                            parseFloat(formatUnits(position.staked1, pool.decimals)) * price1
+                        )
+                    }, 0)
+                    .toString(),
+                earnPlatform: 'velodrome',
+                earnAddress: pool.address,
+                earnLink: `https://velodrome.finance/deposit?token0=${pool.token0}&token1=${pool.token1}&type=${pool.type}`,
+            })
+        }
+        return temp
+    }, [veloData, veloPrices, veloPositions, prices, tokensData])
+
+    const strategies = useMemo(() => {
+        return [...vaultStrategies, ...uniStrategies, ...veloStrategies]
+    }, [vaultStrategies, uniStrategies, veloStrategies])
+
+    const [filterEmpty, setFilterEmpty] = useState(false)
+
+    const filteredRows = useMemo(() => {
+        if (!filterEmpty) return strategies
+
+        return strategies.filter(({ userPosition }) => !!userPosition && userPosition !== '0')
+    }, [strategies, filterEmpty])
+
+    const [sorting, setSorting] = useState<Sorting>({
+        key: 'My Position',
+        dir: 'desc',
+    })
+
+    const sortedRows = useMemo(() => {
+        switch (sorting.key) {
+            case 'Asset / Asset Pair':
+                return arrayToSorted(filteredRows, {
+                    getProperty: (row) => row.pair[0],
+                    dir: sorting.dir,
+                    type: 'alphabetical',
+                })
+            case 'Strategy':
+                return arrayToSorted(filteredRows, {
+                    getProperty: (row) => (row.earnPlatform ? 'farm' : 'borrow'),
+                    dir: sorting.dir,
+                    type: 'alphabetical',
+                })
+            case 'TVP':
+                return arrayToSorted(filteredRows, {
+                    getProperty: (row) => row.tvl,
+                    dir: sorting.dir,
+                    type: 'parseFloat',
+                    checkValueExists: true,
+                })
+            case 'Rewards APY':
+                return arrayToSorted(filteredRows, {
+                    getProperty: (row) => row.apy,
+                    dir: sorting.dir,
+                    type: 'numerical',
+                })
+            case 'My Position':
+            default:
+                return arrayToSorted(filteredRows, {
+                    getProperty: (row) => row.userPosition,
+                    dir: sorting.dir,
+                    type: 'parseFloat',
+                    checkValueExists: true,
+                })
+        }
+    }, [filteredRows, sorting])
+
+    return {
+        headers: sortableHeaders,
+        rows: sortedRows,
+        rowsUnmodified: strategies,
+        loading: loading || uniLoading || veloLoading,
+        error: error?.message,
+        uniError: uniError?.message,
+        veloError,
+        sorting,
+        setSorting,
+        filterEmpty,
+        setFilterEmpty,
+    }
+}
+
+const calculateAPY = (
+    tvl: number,
+    prices: { KITE: number; OP: number },
+    rewards: { KITE: number; OP: number } = REWARDS.default
+) => {
+    if (!tvl) return 0
+    if (!prices.KITE || !prices.OP) return 0
+
+    // ((kite-daily-emission * kite-price + op-daily-emission * op-price) * 365) / (hai-debt-per-collateral * hai-redemption-price)
+    const nominal = (365 * (rewards.KITE * prices.KITE + rewards.OP * prices.OP)) / tvl
+    return nominal === Infinity ? 0 : Math.pow(1 + nominal / 12, 12) - 1
+}

--- a/src/hooks/useStakeData.tsx
+++ b/src/hooks/useStakeData.tsx
@@ -1,0 +1,16 @@
+// import { useState } from 'react'
+
+export function useStakingData() {
+    return {
+        stats: {
+            tvl: '$101.5',
+            stakedKite: '43.5',
+            stakedKiteShare: '37',
+            haiBoost: '4.5%',
+            stakingRewards: {
+                KITE: '14',
+                OP: '24',
+            },
+        },
+    }
+}

--- a/src/hooks/useStakingData.tsx
+++ b/src/hooks/useStakingData.tsx
@@ -1,0 +1,12 @@
+import { useStaking } from '~/providers/StakingProvider'
+
+/**
+ * This hook is maintained for backward compatibility.
+ * Use useStaking directly from StakingProvider for new code.
+ */
+export function useStakingData() {
+    return useStaking()
+}
+
+// Re-export everything from the provider
+export * from '~/providers/StakingProvider'

--- a/src/hooks/useStakingSummary.tsx
+++ b/src/hooks/useStakingSummary.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useCallback } from 'react'
+import { utils } from 'ethers'
+import { formatNumberWithStyle } from '~/utils'
+import { useStoreState } from '~/store'
+import { useStakingData } from '~/hooks/useStakingData'
+import { useVelodromePrices } from '~/providers/VelodromePriceProvider'
+import { useBoost } from '~/hooks/useBoost'
+import { useAccount } from 'wagmi'
+
+export type StakingSummaryData = {
+    // Loading state
+    loading: boolean
+    // Optimistic update indication
+    isOptimistic: boolean
+
+    // Price data
+    kitePrice: number
+
+    // Total staking data
+    totalStaked: {
+        amount: number
+        amountFormatted: string
+        usdValue: number
+        usdValueFormatted: string
+    }
+
+    // User staking data
+    myStaked: {
+        amount: number
+        amountFormatted: string
+        usdValue: number
+        usdValueFormatted: string
+        effectiveAmount: number
+        effectiveAmountFormatted: string
+    }
+
+    // Share and statistics
+    myShare: {
+        value: number
+        percentage: string
+    }
+
+    // APR and rewards
+    stakingApr: {
+        value: number
+        formatted: string
+    }
+
+    // Boost data
+    boost: {
+        netBoostValue: number
+        netBoostFormatted: string
+        boostedValue: number
+        boostedValueFormatted: string
+        haiVeloBoost: number
+        lpBoost: number
+        haiVeloPositionValue: number
+        userLPPositionValue: number
+    }
+
+    // Raw data access
+    stakingData: any
+
+    // Simulation function
+    simulateNetBoost: (userAfterStakingAmount: number, totalAfterStakingAmount: number) => number
+
+    // Simulation helper
+    calculateSimulatedValues: (
+        stakingAmount: string,
+        unstakingAmount: string
+    ) => {
+        simulationMode: boolean
+        totalStakedAfterTx: number
+        myStakedAfterTx: number
+        myShareAfterTx: number
+        netBoostAfterTx: number
+    }
+}
+
+export function useStakingSummary(): StakingSummaryData {
+    const { address } = useAccount()
+    const {
+        stakingData,
+        stakingStats,
+        loading: stakingLoading,
+        stakingApyData,
+        totalStaked,
+        stakedBalance,
+        usersStakingData,
+    } = useStakingData()
+    const { prices: veloPrices } = useVelodromePrices()
+    const isOptimistic = useStoreState((state) => state.stakingModel.isOptimistic)
+    // const optimisticData = useStoreState((state) => state.stakingModel.optimisticData)
+    const {
+        // userHaiVELODeposited,
+        // totalHaiVELODeposited,
+        // userKITEStaked,
+        // totalKITEStaked,
+        // userLPPosition,
+        // totalPoolLiquidity,
+        userLPPositionValue,
+        lpBoostValue,
+        userTotalValue,
+        hvBoost,
+        simulateNetBoost,
+        netBoostValue,
+        haiVeloPositionValue,
+        loading: boostLoading,
+    } = useBoost()
+
+    const {
+        vaultModel: { liquidationData },
+    } = useStoreState((state) => state)
+
+    // Extract prices from various sources
+    const haiPrice = parseFloat(liquidationData?.currentRedemptionPrice || '1')
+    const kitePrice = Number(veloPrices?.KITE?.raw || 0)
+    const opPrice = Number(liquidationData?.collateralLiquidationData?.OP?.currentPrice.value || 0)
+
+    // Set up reward token addresses and prices
+    const HAI_ADDRESS = import.meta.env.VITE_HAI_ADDRESS as string
+    const KITE_ADDRESS = import.meta.env.VITE_KITE_ADDRESS as string
+    const OP_ADDRESS = import.meta.env.VITE_OP_ADDRESS as string
+
+    const rewardsDataMap: Record<string, number> = {
+        [HAI_ADDRESS]: haiPrice,
+        [KITE_ADDRESS]: kitePrice,
+        [OP_ADDRESS]: opPrice,
+    }
+
+    // Calculate staking APR
+    const stakingApyRewardsTotal = useMemo(() => {
+        return stakingApyData.reduce(
+            (acc, item) => {
+                // Access price based on token address
+                const price = rewardsDataMap[item.rpToken as string] || 0
+                const scaledPrice = utils.parseUnits(price.toString(), 18)
+                const amount = item.rpRate.mul(scaledPrice)
+                const nextAcc = acc.add(amount)
+                return nextAcc
+            },
+            utils.parseUnits('0', 18)
+        )
+    }, [stakingApyData, rewardsDataMap])
+
+    // Calculate total staking APR
+    const stakingApr = useMemo(() => {
+        const totalStakedNumber = Number(stakingStats.totalStaked) || 0
+        let aprValue = 0
+
+        if (!isNaN(totalStakedNumber) && totalStakedNumber !== 0 && kitePrice !== 0) {
+            const stakingApyRewardsTotalYearly = stakingApyRewardsTotal.mul(31536000)
+
+            const scaledKitePrice = utils.parseUnits(kitePrice.toString(), 18)
+            const scaledTotalStaked = utils.parseUnits(totalStakedNumber.toString(), 18)
+            const scaledTotalStakedUSD = scaledTotalStaked.mul(scaledKitePrice)
+
+            aprValue = Number(stakingApyRewardsTotalYearly.mul(10000).div(scaledTotalStakedUSD).toString())
+        }
+
+        return {
+            value: aprValue,
+            formatted: `${formatNumberWithStyle(aprValue, {
+                minDecimals: 0,
+                maxDecimals: 2,
+                scalingFactor: 1 / 100,
+            })}%`,
+        }
+    }, [stakingApyRewardsTotal, stakingStats.totalStaked, kitePrice])
+
+    // Calculate effective staked balance (actual - pending withdrawals)
+    const effectiveStakedBalance = useMemo(() => {
+        if (!address) return 0
+        // Ensure stakedBalance is treated as a string
+        const balanceStr = usersStakingData[address.toLowerCase()]?.stakedBalance || '0'
+
+        // typeof stakedBalance === 'string' ? stakedBalance : String(stakedBalance || '0')
+
+        // Ensure pendingWithdrawal.amount is treated as a string
+        // const pendingAmount = stakingData.pendingWithdrawal
+        //     ? Number(String(stakingData.pendingWithdrawal.amount || '0'))
+        //     : 0
+
+        return Number(balanceStr) //+ pendingAmount
+    }, [stakedBalance, usersStakingData, stakingData.pendingWithdrawal, address])
+
+    // Function to calculate simulated values for staking/unstaking
+    const calculateSimulatedValues = useCallback(
+        (stakingAmount: string, unstakingAmount: string) => {
+            const stakeAmountNum = Number(stakingAmount) || 0
+            const unstakeAmountNum = Number(unstakingAmount) || 0
+            const totalStakedValue = Number(totalStaked) / 10 ** 18
+            const simulationMode = Boolean(
+                (stakingAmount || unstakingAmount) && (stakeAmountNum > 0 || unstakeAmountNum > 0)
+            )
+
+            // Calculate simulated values
+            const totalStakedAfterTx = totalStakedValue + stakeAmountNum - unstakeAmountNum
+            const myStakedAfterTx = effectiveStakedBalance + stakeAmountNum - unstakeAmountNum
+            const myShareAfterTx = totalStakedAfterTx !== 0 ? (myStakedAfterTx / totalStakedAfterTx) * 100 : 0
+
+            // Calculate simulated boost
+            const netBoostAfterTx = simulateNetBoost(myStakedAfterTx, totalStakedAfterTx)
+
+            return {
+                simulationMode,
+                totalStakedAfterTx,
+                myStakedAfterTx,
+                myShareAfterTx,
+                netBoostAfterTx,
+            }
+        },
+        [effectiveStakedBalance, totalStaked, simulateNetBoost]
+    )
+
+    // Calculate base staking data
+    const stakingSummary = useMemo(() => {
+        const isLoading = stakingLoading || boostLoading
+
+        if (isLoading) {
+            return null
+        }
+
+        const totalStakedValue = Number(totalStaked) / 10 ** 18
+        const totalStakedUSD = totalStakedValue * kitePrice
+        const myStakedUSD = effectiveStakedBalance * kitePrice
+        const myShare = totalStakedValue !== 0 ? (effectiveStakedBalance / totalStakedValue) * 100 : 0
+
+        // Ensure numeric value for positions
+        const numericHaiVeloPositionValue =
+            typeof haiVeloPositionValue === 'string' ? Number(haiVeloPositionValue) : haiVeloPositionValue || 0
+
+        const numericUserLPPositionValue =
+            typeof userLPPositionValue === 'string' ? Number(userLPPositionValue) : userLPPositionValue || 0
+
+        return {
+            // Loading state
+            loading: isLoading,
+            // Optimistic update indication
+            isOptimistic,
+
+            // Price data
+            kitePrice,
+
+            // Total staking data
+            totalStaked: {
+                amount: totalStakedValue,
+                amountFormatted: formatNumberWithStyle(totalStakedValue, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                }),
+                usdValue: totalStakedUSD,
+                usdValueFormatted: formatNumberWithStyle(totalStakedUSD, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                    style: 'currency',
+                }),
+            },
+
+            // User staking data
+            myStaked: {
+                amount: Number(stakingData.stakedBalance),
+                amountFormatted: formatNumberWithStyle(Number(stakingData.stakedBalance), {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                }),
+                effectiveAmount: effectiveStakedBalance,
+                effectiveAmountFormatted: formatNumberWithStyle(effectiveStakedBalance, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                }),
+                usdValue: myStakedUSD,
+                usdValueFormatted: formatNumberWithStyle(myStakedUSD, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                    style: 'currency',
+                }),
+            },
+
+            // Share and statistics
+            myShare: {
+                value: myShare,
+                percentage: formatNumberWithStyle(myShare, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                    style: 'percent',
+                    scalingFactor: 0.01,
+                }),
+            },
+
+            // APR data
+            stakingApr,
+
+            // Boost data
+            boost: {
+                netBoostValue,
+                netBoostFormatted:
+                    formatNumberWithStyle(netBoostValue, {
+                        minDecimals: 0,
+                        maxDecimals: 2,
+                    }) + 'x',
+                boostedValue: userTotalValue,
+                boostedValueFormatted: formatNumberWithStyle(userTotalValue, {
+                    minDecimals: 0,
+                    maxDecimals: 2,
+                    style: 'currency',
+                }),
+                haiVeloBoost: hvBoost,
+                lpBoost: lpBoostValue,
+                haiVeloPositionValue: numericHaiVeloPositionValue,
+                userLPPositionValue: numericUserLPPositionValue,
+            },
+
+            // Raw data access
+            stakingData,
+        }
+    }, [
+        stakingLoading,
+        boostLoading,
+        totalStaked,
+        stakingData,
+        kitePrice,
+        effectiveStakedBalance,
+        stakingApr,
+        netBoostValue,
+        userTotalValue,
+        hvBoost,
+        lpBoostValue,
+        haiVeloPositionValue,
+        userLPPositionValue,
+        isOptimistic,
+    ])
+
+    // Default values when loading or data is not available
+    const defaultSummary: StakingSummaryData = {
+        loading: true,
+        isOptimistic: false,
+        kitePrice: 0,
+        totalStaked: {
+            amount: 0,
+            amountFormatted: '0',
+            usdValue: 0,
+            usdValueFormatted: '$0',
+        },
+        myStaked: {
+            amount: 0,
+            amountFormatted: '0',
+            effectiveAmount: 0,
+            effectiveAmountFormatted: '0',
+            usdValue: 0,
+            usdValueFormatted: '$0',
+        },
+        myShare: {
+            value: 0,
+            percentage: '0%',
+        },
+        stakingApr: {
+            value: 0,
+            formatted: '0%',
+        },
+        boost: {
+            netBoostValue: 1,
+            netBoostFormatted: '1x',
+            boostedValue: 0,
+            boostedValueFormatted: '$0',
+            haiVeloBoost: 0,
+            lpBoost: 0,
+            haiVeloPositionValue: 0,
+            userLPPositionValue: 0,
+        },
+        stakingData: {},
+        simulateNetBoost,
+        calculateSimulatedValues,
+    }
+
+    // Return all necessary data and functions
+    return stakingSummary
+        ? {
+              ...stakingSummary,
+              stakingData,
+              simulateNetBoost,
+              calculateSimulatedValues,
+          }
+        : defaultSummary
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -4,6 +4,8 @@ import { type ConnectWalletModel, connectWalletModel } from './connectWalletMode
 import { type VaultModel, vaultModel } from './vaultModel'
 import { type TransactionsModel, transactionsModel } from './transactionsModel'
 import { type AuctionModel, auctionModel } from './auctionModel'
+import { type StakingModel, stakingModel } from './stakingModel'
+import { type LPDataModel, lpDataModel } from './lpDataModel'
 
 export interface StoreModel {
     auctionModel: AuctionModel
@@ -12,6 +14,8 @@ export interface StoreModel {
     settingsModel: SettingsModel
     transactionsModel: TransactionsModel
     vaultModel: VaultModel
+    stakingModel: StakingModel
+    lpDataModel: LPDataModel
 }
 
 export const model: StoreModel = {
@@ -21,4 +25,6 @@ export const model: StoreModel = {
     settingsModel,
     transactionsModel,
     vaultModel,
+    stakingModel,
+    lpDataModel,
 }

--- a/src/model/lpDataModel.ts
+++ b/src/model/lpDataModel.ts
@@ -1,0 +1,506 @@
+import { type Action, type Thunk, action, thunk } from 'easy-peasy'
+import * as lpDataService from '~/services/lpData'
+import { calculateLPBoost } from '~/services/boostService'
+// import type { StoreModel } from './index'
+
+// Define user position type
+export type UserPosition = {
+    id: string
+    liquidity: string
+    depositedToken0: string
+    depositedToken1: string
+    withdrawnToken0: string
+    withdrawnToken1: string
+    tickLower: {
+        tickIdx: string
+    }
+    tickUpper: {
+        tickIdx: string
+    }
+    owner: string
+}
+
+// Define current user position type
+export type CurrentUserPosition = {
+    id: string
+    liquidity: string
+    currentToken0: string // Current amount of token0 in the position
+    currentToken1: string // Current amount of token1 in the position
+    tickLower: {
+        tickIdx: string
+    }
+    tickUpper: {
+        tickIdx: string
+    }
+    owner: string
+}
+
+// Define pool data type
+export type PoolData = {
+    id: string
+    liquidity: string
+    totalValueLockedToken0: string
+    totalValueLockedToken1: string
+    totalValueLockedUSD: string
+    token0: {
+        symbol: string
+        decimals: number
+    }
+    token1: {
+        symbol: string
+        decimals: number
+    }
+    token0Price: string
+    token1Price: string
+    tick: string
+    sqrtPrice: string
+}
+
+// Type for user position mappings
+export type UserPositionsMap = Record<string, UserPosition[]>
+
+// Type for user current position mappings
+export type UserCurrentPositionsMap = Record<string, CurrentUserPosition[]>
+
+// Type for user position value mappings
+export type UserPositionValuesMap = Record<string, number>
+
+// Type for user total liquidity mappings
+export type UserTotalLiquidityMap = Record<string, string>
+
+// NEW - Type for LP boost related data
+export type UserLPBoostMap = Record<string, number>
+export type UserKiteRatioMap = Record<string, number>
+
+export interface LPDataModel {
+    // Original state for backward compatibility
+    pool: PoolData | null
+    setPool: Action<LPDataModel, PoolData | null>
+    userPositions: UserPosition[] | null
+    setUserPositions: Action<LPDataModel, UserPosition[] | null>
+    userCurrentPositionComposition: CurrentUserPosition[] | null
+    setUserCurrentPositionComposition: Action<LPDataModel, CurrentUserPosition[] | null>
+    loading: boolean
+    setLoading: Action<LPDataModel, boolean>
+    error: any
+    setError: Action<LPDataModel, any>
+    account: string | undefined
+    setAccount: Action<LPDataModel, string | undefined>
+
+    // New state for enhanced functionality
+    allPositions: UserPosition[] | null
+    setAllPositions: Action<LPDataModel, UserPosition[] | null>
+    userPositionsMap: UserPositionsMap
+    setUserPositionsMap: Action<LPDataModel, UserPositionsMap>
+    userCurrentPositionsMap: UserCurrentPositionsMap
+    setUserCurrentPositionsMap: Action<LPDataModel, UserCurrentPositionsMap>
+
+    // Position values and liquidity tracking
+    token0UsdPrice: number
+    setToken0UsdPrice: Action<LPDataModel, number>
+    token1UsdPrice: number
+    setToken1UsdPrice: Action<LPDataModel, number>
+    userPositionValuesMap: UserPositionValuesMap
+    setUserPositionValuesMap: Action<LPDataModel, UserPositionValuesMap>
+    userTotalLiquidityMap: UserTotalLiquidityMap
+    setUserTotalLiquidityMap: Action<LPDataModel, UserTotalLiquidityMap>
+
+    // NEW - LP boost related state
+    userLPBoostMap: UserLPBoostMap
+    setUserLPBoostMap: Action<LPDataModel, UserLPBoostMap>
+    userKiteRatioMap: UserKiteRatioMap
+    setUserKiteRatioMap: Action<LPDataModel, UserKiteRatioMap>
+
+    // For backward compatibility with useBoost
+    userLPPositionValue: string
+    setUserLPPositionValue: Action<LPDataModel, string>
+    userTotalLiquidity: string
+    setUserTotalLiquidity: Action<LPDataModel, string>
+
+    // Actions and thunks
+    fetchPoolData: Thunk<LPDataModel>
+    fetchUserPositions: Thunk<LPDataModel, string | undefined>
+    calculateCurrentPositions: Thunk<LPDataModel>
+
+    // New thunks
+    fetchAllPositions: Thunk<LPDataModel>
+    buildUserPositionsMap: Thunk<LPDataModel>
+    calculateAllCurrentPositions: Thunk<LPDataModel>
+    updateUserData: Thunk<LPDataModel, string | undefined>
+
+    // Token prices and position values
+    updateTokenPrices: Thunk<LPDataModel, { token0UsdPrice: number; token1UsdPrice: number }>
+    calculateAllPositionValues: Thunk<LPDataModel>
+    calculateAllUserLiquidity: Thunk<LPDataModel>
+
+    // NEW - LP boost calculation thunks
+    calculateAllUserLPBoosts: Thunk<
+        LPDataModel,
+        {
+            usersStakingData: Record<string, any>
+            totalStaked: string
+        }
+    >
+}
+
+export const lpDataModel: LPDataModel = {
+    // Original state
+    pool: null,
+    setPool: action((state, payload) => {
+        state.pool = payload
+    }),
+    userPositions: null,
+    setUserPositions: action((state, payload) => {
+        state.userPositions = payload
+    }),
+    userCurrentPositionComposition: null,
+    setUserCurrentPositionComposition: action((state, payload) => {
+        state.userCurrentPositionComposition = payload
+    }),
+    loading: false,
+    setLoading: action((state, payload) => {
+        state.loading = payload
+    }),
+    error: null,
+    setError: action((state, payload) => {
+        state.error = payload
+    }),
+    account: undefined,
+    setAccount: action((state, payload) => {
+        state.account = payload
+    }),
+
+    // New state
+    allPositions: null,
+    setAllPositions: action((state, payload) => {
+        state.allPositions = payload
+    }),
+    userPositionsMap: {},
+    setUserPositionsMap: action((state, payload) => {
+        state.userPositionsMap = payload
+    }),
+    userCurrentPositionsMap: {},
+    setUserCurrentPositionsMap: action((state, payload) => {
+        state.userCurrentPositionsMap = payload
+    }),
+
+    // Position values and liquidity tracking
+    token0UsdPrice: 0,
+    setToken0UsdPrice: action((state, payload) => {
+        state.token0UsdPrice = payload
+    }),
+    token1UsdPrice: 0,
+    setToken1UsdPrice: action((state, payload) => {
+        state.token1UsdPrice = payload
+    }),
+    userPositionValuesMap: {},
+    setUserPositionValuesMap: action((state, payload) => {
+        state.userPositionValuesMap = payload
+    }),
+    userTotalLiquidityMap: {},
+    setUserTotalLiquidityMap: action((state, payload) => {
+        state.userTotalLiquidityMap = payload
+    }),
+
+    // NEW - LP boost related state
+    userLPBoostMap: {},
+    setUserLPBoostMap: action((state, payload) => {
+        state.userLPBoostMap = payload
+    }),
+    userKiteRatioMap: {},
+    setUserKiteRatioMap: action((state, payload) => {
+        state.userKiteRatioMap = payload
+    }),
+
+    // For backward compatibility
+    userLPPositionValue: '0',
+    setUserLPPositionValue: action((state, payload) => {
+        state.userLPPositionValue = payload
+    }),
+    userTotalLiquidity: '0',
+    setUserTotalLiquidity: action((state, payload) => {
+        state.userTotalLiquidity = payload
+    }),
+
+    // Original thunks
+    fetchPoolData: thunk(async (actions) => {
+        try {
+            actions.setLoading(true)
+            const poolData = await lpDataService.fetchPoolData()
+
+            if (poolData) {
+                actions.setPool(poolData)
+            }
+            actions.setLoading(false)
+        } catch (err) {
+            console.error('Error fetching LP data:', err)
+            actions.setError(err)
+            actions.setLoading(false)
+        }
+    }),
+
+    fetchUserPositions: thunk(async (actions, account, { getState }) => {
+        if (!account) {
+            actions.setUserPositions(null)
+            return
+        }
+
+        try {
+            actions.setLoading(true)
+
+            // Try to get user positions from the map first
+            const { allPositions } = getState()
+            if (allPositions) {
+                const userPositions = lpDataService.getUserPositionsFromAll(allPositions, account)
+                actions.setUserPositions(userPositions)
+            } else {
+                // Fallback to direct fetch (though this should be deprecated)
+                const positions = await lpDataService.fetchUserPositions(account)
+                if (positions) {
+                    actions.setUserPositions(positions)
+                }
+            }
+
+            actions.setLoading(false)
+        } catch (err) {
+            console.error('Error fetching user positions:', err)
+            actions.setError(err)
+            actions.setLoading(false)
+        }
+    }),
+
+    calculateCurrentPositions: thunk(async (actions, _, { getState }) => {
+        const { userPositions, pool } = getState()
+
+        if (!userPositions || !pool || userPositions.length === 0) {
+            actions.setUserCurrentPositionComposition(null)
+            return
+        }
+
+        try {
+            const currentPositions = lpDataService.calculateCurrentPositionComposition(userPositions, pool)
+
+            if (currentPositions) {
+                actions.setUserCurrentPositionComposition(currentPositions)
+            }
+        } catch (err) {
+            console.error('Error calculating current positions:', err)
+            actions.setError(err)
+        }
+    }),
+
+    // New thunks
+    fetchAllPositions: thunk(async (actions) => {
+        try {
+            actions.setLoading(true)
+            const allPositions = await lpDataService.fetchAllActivePositions()
+
+            if (allPositions) {
+                actions.setAllPositions(allPositions)
+            }
+
+            actions.setLoading(false)
+        } catch (err) {
+            console.error('Error fetching all positions:', err)
+            actions.setError(err)
+            actions.setLoading(false)
+        }
+    }),
+
+    buildUserPositionsMap: thunk(async (actions, _, { getState }) => {
+        const { allPositions } = getState()
+
+        if (!allPositions || allPositions.length === 0) {
+            return
+        }
+
+        try {
+            const userMap = lpDataService.groupPositionsByUser(allPositions)
+            actions.setUserPositionsMap(userMap)
+        } catch (err) {
+            console.error('Error building user positions map:', err)
+            actions.setError(err)
+        }
+    }),
+
+    calculateAllCurrentPositions: thunk(async (actions, _, { getState }) => {
+        const { userPositionsMap, pool } = getState()
+
+        if (!userPositionsMap || !pool || Object.keys(userPositionsMap).length === 0) {
+            return
+        }
+
+        try {
+            const userCurrentPositionsMap: UserCurrentPositionsMap = {}
+
+            // Calculate current positions for each user
+            for (const [address, positions] of Object.entries(userPositionsMap)) {
+                const currentPositions = lpDataService.calculateCurrentPositionComposition(positions, pool)
+                if (currentPositions) {
+                    userCurrentPositionsMap[address] = currentPositions
+                }
+            }
+
+            actions.setUserCurrentPositionsMap(userCurrentPositionsMap)
+        } catch (err) {
+            console.error('Error calculating all current positions:', err)
+            actions.setError(err)
+        }
+    }),
+
+    // Update all user data - central point for updating account-specific data
+    updateUserData: thunk(async (actions, account, { getState, getStoreActions }) => {
+        if (!account) return
+
+        const { allPositions, pool, userPositionValuesMap, userTotalLiquidityMap } = getState()
+        // Get actions directly - we'll use a workaround for typing
+        const storeActions = getStoreActions() as any
+
+        // If we don't have the pool data or all positions yet, fetch them
+        if (!pool) {
+            await storeActions.lpDataModel.fetchPoolData()
+        }
+
+        if (!allPositions) {
+            await storeActions.lpDataModel.fetchAllPositions()
+            await storeActions.lpDataModel.buildUserPositionsMap()
+            await storeActions.lpDataModel.calculateAllCurrentPositions()
+        }
+
+        // Update the current user's data for backward compatibility
+        const { allPositions: updatedAllPositions, userCurrentPositionsMap } = getState()
+        if (updatedAllPositions) {
+            const userPositions = lpDataService.getUserPositionsFromAll(updatedAllPositions, account.toLowerCase())
+            actions.setUserPositions(userPositions)
+
+            // Set current position composition from the map if available
+            const normalizedAddress = account.toLowerCase()
+            if (userCurrentPositionsMap && userCurrentPositionsMap[normalizedAddress]) {
+                actions.setUserCurrentPositionComposition(userCurrentPositionsMap[normalizedAddress])
+            } else {
+                // Otherwise calculate it directly (should be rare with the new flow)
+                await storeActions.lpDataModel.calculateCurrentPositions()
+            }
+
+            // Update backward compatibility values for the user
+            if (userPositionValuesMap && userPositionValuesMap[normalizedAddress]) {
+                actions.setUserLPPositionValue(userPositionValuesMap[normalizedAddress].toString())
+            }
+
+            if (userTotalLiquidityMap && userTotalLiquidityMap[normalizedAddress]) {
+                actions.setUserTotalLiquidity(userTotalLiquidityMap[normalizedAddress])
+            }
+        }
+    }),
+
+    // Token prices and position values
+    updateTokenPrices: thunk(async (actions, { token0UsdPrice, token1UsdPrice }) => {
+        actions.setToken0UsdPrice(token0UsdPrice)
+        actions.setToken1UsdPrice(token1UsdPrice)
+    }),
+
+    calculateAllPositionValues: thunk(async (actions, _, { getState }) => {
+        const { userPositionsMap, pool, token0UsdPrice, token1UsdPrice, account } = getState()
+
+        if (
+            !userPositionsMap ||
+            !pool ||
+            Object.keys(userPositionsMap).length === 0 ||
+            token0UsdPrice === 0 ||
+            token1UsdPrice === 0
+        ) {
+            return
+        }
+
+        try {
+            const userPositionValuesMap = lpDataService.calculateAllUserPositionValues(
+                userPositionsMap,
+                pool,
+                token0UsdPrice,
+                token1UsdPrice
+            )
+
+            actions.setUserPositionValuesMap(userPositionValuesMap)
+
+            // Update for backward compatibility if there's a current account
+            if (account && userPositionValuesMap[account.toLowerCase()]) {
+                actions.setUserLPPositionValue(userPositionValuesMap[account.toLowerCase()].toString())
+            }
+        } catch (err) {
+            console.error('Error calculating position values:', err)
+            actions.setError(err)
+        }
+    }),
+
+    calculateAllUserLiquidity: thunk(async (actions, _, { getState }) => {
+        const { userPositionsMap, account } = getState()
+
+        if (!userPositionsMap || Object.keys(userPositionsMap).length === 0) {
+            return
+        }
+
+        try {
+            const userTotalLiquidityMap = lpDataService.calculateAllUserTotalLiquidity(userPositionsMap)
+
+            actions.setUserTotalLiquidityMap(userTotalLiquidityMap)
+
+            // Update for backward compatibility if there's a current account
+            if (account && userTotalLiquidityMap[account.toLowerCase()]) {
+                actions.setUserTotalLiquidity(userTotalLiquidityMap[account.toLowerCase()])
+            }
+        } catch (err) {
+            console.error('Error calculating user total liquidity:', err)
+            actions.setError(err)
+        }
+    }),
+
+    // NEW - Calculate LP boost values for all users
+    calculateAllUserLPBoosts: thunk(async (actions, { usersStakingData, totalStaked }, { getState }) => {
+        const { userTotalLiquidityMap, pool } = getState()
+
+        if (!userTotalLiquidityMap || !pool || Object.keys(userTotalLiquidityMap).length === 0) {
+            return
+        }
+
+        try {
+            const totalPoolLiquidity = pool.liquidity || '0'
+            const userLPBoostMap: UserLPBoostMap = {}
+            const userKiteRatioMap: UserKiteRatioMap = {}
+
+            // Calculate LP boost for each user
+            for (const [address, userLiquidity] of Object.entries(userTotalLiquidityMap)) {
+                // Get user staking data if available
+                const userStakingData = usersStakingData[address]
+                const userStakingAmount = userStakingData ? Number(userStakingData.stakedBalance) : 0
+
+                // Calculate KITE ratio (user's staked KITE / total staked KITE)
+                const totalStakingAmount = Number(totalStaked) / 10 ** 18
+                const calculatedKiteRatio =
+                    isNaN(totalStakingAmount) || totalStakingAmount === 0 ? 0 : userStakingAmount / totalStakingAmount
+
+                userKiteRatioMap[address] = calculatedKiteRatio
+
+                // Skip further calculation if user has no stake
+                if (userStakingAmount <= 0) {
+                    userLPBoostMap[address] = 1
+                    continue
+                }
+
+                const lpBoost = calculateLPBoost({
+                    userStakingAmount,
+                    totalStakingAmount,
+                    userLPPosition: userLiquidity,
+                    totalPoolLiquidity,
+                }).lpBoost
+
+                userLPBoostMap[address] = lpBoost
+            }
+
+            actions.setUserLPBoostMap(userLPBoostMap)
+            actions.setUserKiteRatioMap(userKiteRatioMap)
+        } catch (err) {
+            console.error('Error calculating LP boosts:', err)
+            actions.setError(err)
+        }
+    }),
+}

--- a/src/model/popupsModel.ts
+++ b/src/model/popupsModel.ts
@@ -35,6 +35,9 @@ export interface PopupsModel {
     isClaimPopupOpen: boolean
     setIsClaimPopupOpen: Action<PopupsModel, boolean>
 
+    isStakeClaimPopupOpen: boolean
+    setIsStakeClaimPopupOpen: Action<PopupsModel, boolean>
+
     // isVotingModalOpen: boolean
     // setIsVotingModalOpen: Action<PopupsModel, boolean>
 
@@ -132,6 +135,11 @@ export const popupsModel: PopupsModel = {
     isClaimPopupOpen: false,
     setIsClaimPopupOpen: action((state, isOpen) => {
         state.isClaimPopupOpen = isOpen
+    }),
+
+    isStakeClaimPopupOpen: false,
+    setIsStakeClaimPopupOpen: action((state, isOpen) => {
+        state.isStakeClaimPopupOpen = isOpen
     }),
 
     // isVotingModalOpen: false,

--- a/src/model/stakingModel.ts
+++ b/src/model/stakingModel.ts
@@ -1,0 +1,728 @@
+import { type Action, type Thunk, action, thunk } from 'easy-peasy'
+import { JsonRpcSigner, Provider } from '@ethersproject/providers'
+import { BigNumber, Contract } from 'ethers'
+import { parseEther } from 'ethers/lib/utils'
+import * as ethers from 'ethers'
+
+import { type StoreModel } from './index'
+import { ActionState } from '~/utils'
+import { handlePreTxGasEstimate } from '~/hooks'
+import StakingManagerABI from '~/abis/StakingManager.json'
+import RewardPoolABI from '~/abis/RewardPool.json'
+
+// const ERC20ABI = [
+//     {
+//         constant: true,
+//         inputs: [{ name: '_owner', type: 'address' }],
+//         name: 'balanceOf',
+//         outputs: [{ name: 'balance', type: 'uint256' }],
+//         payable: false,
+//         stateMutability: 'view',
+//         type: 'function',
+//     },
+// ]
+
+// User staking data interface
+export interface UserStakingData {
+    id: string
+    stakedBalance: string
+    pendingWithdrawal?: {
+        amount: number
+        timestamp: number
+    }
+}
+
+export interface StakingModel {
+    stakedAmount: string
+    totalStaked: string
+    setTotalStaked: Action<StakingModel, string>
+    fetchTotalStaked: Thunk<StakingModel, { signer?: JsonRpcSigner; provider?: Provider }, any, StoreModel>
+
+    // Add stakedBalance to track user's staked amount
+    stakedBalance: string
+    setStakedBalance: Action<StakingModel, string>
+    fetchUserStakedBalance: Thunk<StakingModel, { signer: JsonRpcSigner }, BigNumber, StoreModel>
+
+    // Users mapping to store all users' staking data
+    usersStakingData: Record<string, UserStakingData>
+    setUsersStakingData: Action<StakingModel, Record<string, UserStakingData>>
+    updateUserStakingData: Action<StakingModel, { userId: string; data: Partial<UserStakingData> }>
+
+    pendingWithdrawals: Record<
+        string,
+        {
+            amount: number
+            timestamp: number
+            status: 'PENDING' | 'COMPLETED' | 'CANCELLED'
+        } | null
+    >
+    setPendingWithdrawals: Action<
+        StakingModel,
+        Record<
+            string,
+            {
+                amount: number
+                timestamp: number
+                status: 'PENDING' | 'COMPLETED' | 'CANCELLED'
+            } | null
+        >
+    >
+
+    // Optimistic state tracking
+    isOptimistic: boolean
+    optimisticData: {
+        stakedBalance?: string
+        totalStaked?: string
+        pendingWithdrawal?: {
+            amount: number
+            timestamp: number
+        }
+    }
+    setOptimisticState: Action<StakingModel, boolean>
+    setOptimisticData: Action<StakingModel, Partial<StakingModel['optimisticData']>>
+    clearOptimisticData: Action<StakingModel>
+
+    // Enhanced existing functions
+    applyOptimisticStake: Action<StakingModel, { amount: string; userAddress: string }>
+    applyOptimisticUnstake: Action<StakingModel, { amount: string; userAddress: string }>
+    applyOptimisticWithdraw: Action<StakingModel, { userAddress: string }>
+    applyOptimisticCancelWithdrawal: Action<StakingModel, { amount: string; userAddress: string }>
+
+    stake: Thunk<StakingModel, { signer: JsonRpcSigner; amount: string }, any, StoreModel>
+    unstake: Thunk<StakingModel, { signer: JsonRpcSigner; amount: string }, any, StoreModel>
+    withdraw: Thunk<StakingModel, { signer: JsonRpcSigner }, any, StoreModel>
+    getReward: Thunk<StakingModel, { signer: JsonRpcSigner }, any, StoreModel>
+    cancelWithdrawal: Thunk<StakingModel, { signer: JsonRpcSigner }, any, StoreModel>
+
+    transactionState: ActionState
+    setTransactionState: Action<StakingModel, ActionState>
+
+    cooldownPeriod: string
+    setCooldownPeriod: Action<StakingModel, string>
+    fetchCooldownPeriod: Thunk<StakingModel, { signer?: JsonRpcSigner; provider?: Provider }, any, StoreModel>
+
+    userRewards: Array<{
+        id: number
+        amount: BigNumber
+        tokenAddress: string
+    }>
+    setUserRewards: Action<StakingModel, Array<{ id: number; amount: BigNumber; tokenAddress: string }>>
+    fetchUserRewards: Thunk<StakingModel, { signer: JsonRpcSigner }, any, StoreModel>
+
+    stakingApyData: Array<{ id: number; rpRate: BigNumber; rpToken: string }>
+    setStakingApyData: Action<StakingModel, Array<{ id: number; rpRate: BigNumber; rpToken: string }>>
+    fetchStakingApyData: Thunk<StakingModel, { signer?: JsonRpcSigner; provider?: Provider }, any, StoreModel>
+}
+
+// Helper function for retrying async operations
+async function retryAsync<T>(fn: () => Promise<T>, retries = 5, delayMs = 30000): Promise<T> {
+    let lastError: any
+    for (let attempt = 0; attempt < retries; attempt++) {
+        try {
+            return await fn()
+        } catch (err) {
+            lastError = err
+            if (attempt < retries - 1) {
+                await new Promise((res) => setTimeout(res, delayMs))
+            }
+        }
+    }
+    throw lastError
+}
+
+export const stakingModel: StakingModel = {
+    stakedAmount: '0',
+    totalStaked: '0',
+    setTotalStaked: action((state, payload) => {
+        state.totalStaked = payload
+    }),
+
+    stakedBalance: '0',
+    setStakedBalance: action((state, payload) => {
+        state.stakedBalance = payload
+    }),
+
+    // Initialize empty users mapping
+    usersStakingData: {},
+    setUsersStakingData: action((state, payload) => {
+        state.usersStakingData = payload
+    }),
+    updateUserStakingData: action((state, { userId, data }) => {
+        state.usersStakingData[userId] = {
+            ...(state.usersStakingData[userId] || { id: userId, stakedBalance: '0' }),
+            ...data,
+        }
+    }),
+
+    pendingWithdrawals: {},
+    setPendingWithdrawals: action((state, payload) => {
+        state.pendingWithdrawals = payload
+    }),
+
+    // Initialize optimistic state
+    isOptimistic: false,
+    optimisticData: {},
+
+    setOptimisticState: action((state, payload) => {
+        state.isOptimistic = payload
+    }),
+
+    setOptimisticData: action((state, payload) => {
+        state.optimisticData = { ...state.optimisticData, ...payload }
+    }),
+
+    clearOptimisticData: action((state) => {
+        state.optimisticData = {}
+        state.isOptimistic = false
+    }),
+
+    // Apply optimistic updates immediately
+    applyOptimisticStake: action((state, { amount, userAddress }) => {
+        const numAmount = Number(amount)
+        const lowerCaseAddress = userAddress.toLowerCase()
+
+        // Calculate new values
+        const newTotalStaked = String(Number(state.totalStaked) + numAmount * 10 ** 18)
+
+        const newUserBalance = String(
+            Number(state.usersStakingData[lowerCaseAddress]?.stakedBalance || '0') + numAmount
+        )
+
+        // Set optimistic flag and data
+        state.isOptimistic = true
+        state.optimisticData = {
+            ...state.optimisticData,
+            totalStaked: newTotalStaked,
+            stakedBalance: newUserBalance,
+        }
+
+        // Apply changes immediately to state
+        state.totalStaked = newTotalStaked
+
+        // Initialize user data if it doesn't exist
+        if (!state.usersStakingData[lowerCaseAddress]) {
+            state.usersStakingData[lowerCaseAddress] = {
+                id: lowerCaseAddress,
+                stakedBalance: '0',
+            }
+        }
+
+        state.usersStakingData[lowerCaseAddress].stakedBalance = newUserBalance
+    }),
+
+    applyOptimisticUnstake: action((state, { amount, userAddress }) => {
+        const numAmount = Number(amount)
+        const lowerCaseAddress = userAddress.toLowerCase()
+
+        // Calculate new values
+        const newTotalStaked = String(Number(state.totalStaked) - numAmount * 10 ** 18)
+        const currentStakedBalance = Number(state.usersStakingData[lowerCaseAddress]?.stakedBalance || '0')
+        const newUserBalance = String(currentStakedBalance - numAmount)
+
+        // Set optimistic flag and data
+        state.isOptimistic = true
+        state.optimisticData = {
+            ...state.optimisticData,
+            totalStaked: newTotalStaked,
+            stakedBalance: newUserBalance,
+        }
+
+        // Initialize user data if it doesn't exist
+        if (!state.usersStakingData[lowerCaseAddress]) {
+            state.usersStakingData[lowerCaseAddress] = {
+                id: lowerCaseAddress,
+                stakedBalance: '0',
+            }
+        }
+
+        // Update pending withdrawals
+        const currentPendingAmount = state.pendingWithdrawals[lowerCaseAddress]
+            ? state.pendingWithdrawals[lowerCaseAddress]!.amount
+            : 0
+
+        state.pendingWithdrawals = {
+            ...state.pendingWithdrawals,
+            [lowerCaseAddress]: {
+                amount: numAmount + currentPendingAmount,
+                timestamp: Math.floor(Date.now() / 1000),
+                status: 'PENDING',
+            },
+        }
+
+        // Apply changes immediately to state
+        state.totalStaked = newTotalStaked
+        state.usersStakingData[lowerCaseAddress].stakedBalance = newUserBalance
+    }),
+
+    applyOptimisticWithdraw: action((state, { userAddress }) => {
+        const lowerCaseAddress = userAddress.toLowerCase()
+
+        // Set optimistic flag
+        state.isOptimistic = true
+
+        // Initialize user data if it doesn't exist
+        if (!state.usersStakingData[lowerCaseAddress]) {
+            state.usersStakingData[lowerCaseAddress] = {
+                id: lowerCaseAddress,
+                stakedBalance: '0',
+            }
+        }
+
+        // Update pending withdrawal status
+        state.pendingWithdrawals = {
+            ...state.pendingWithdrawals,
+            [lowerCaseAddress]: null,
+        }
+    }),
+
+    applyOptimisticCancelWithdrawal: action((state, { amount, userAddress }) => {
+        const numAmount = Number(amount)
+        const lowerCaseAddress = userAddress.toLowerCase()
+
+        // Calculate new values
+        const newTotalStaked = String(Number(state.totalStaked) + numAmount)
+        const currentStakedBalance = Number(state.usersStakingData[lowerCaseAddress]?.stakedBalance || '0')
+        const newUserBalance = String(currentStakedBalance + numAmount)
+
+        // Set optimistic flag and data
+        state.isOptimistic = true
+        state.optimisticData = {
+            ...state.optimisticData,
+            totalStaked: newTotalStaked,
+            stakedBalance: newUserBalance,
+        }
+
+        // Initialize user data if it doesn't exist
+        if (!state.usersStakingData[lowerCaseAddress]) {
+            state.usersStakingData[lowerCaseAddress] = {
+                id: lowerCaseAddress,
+                stakedBalance: '0',
+            }
+        }
+
+        // Update pending withdrawal status
+        state.pendingWithdrawals = {
+            ...state.pendingWithdrawals,
+            [lowerCaseAddress]: null,
+        }
+
+        // Apply changes immediately to state
+        state.totalStaked = newTotalStaked
+        state.usersStakingData[lowerCaseAddress].stakedBalance = newUserBalance
+    }),
+
+    stake: thunk(async (actions, { signer, amount }, { getStoreActions }) => {
+        // debugger
+        const storeActions = getStoreActions()
+        try {
+            const userAddress = await signer.getAddress()
+
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+
+            const txData = await stakingManager.populateTransaction.stake(await signer.getAddress(), parseEther(amount))
+
+            const tx = await handlePreTxGasEstimate(signer, txData)
+            const txResponse = await signer.sendTransaction(tx)
+
+            // Apply optimistic update immediately after user confirms
+
+            console.log('Applying optimistic stake', amount, userAddress)
+            actions.applyOptimisticStake({ amount, userAddress })
+
+            storeActions.transactionsModel.addTransaction({
+                chainId: await signer.getChainId(),
+                hash: txResponse.hash,
+                from: txResponse.from,
+                summary: 'Staking KITE',
+                addedTime: new Date().getTime(),
+                originalTx: txResponse,
+            })
+
+            storeActions.popupsModel.setWaitingPayload({
+                title: 'Transaction Submitted',
+                hash: txResponse.hash,
+                status: ActionState.SUCCESS,
+            })
+
+            await txResponse.wait()
+
+            // Transaction successful, now get real data
+            await actions.fetchTotalStaked({ signer })
+
+            await actions.fetchUserStakedBalance({ signer })
+
+            // Keep optimistic flag for a while until GraphQL is updated
+            setTimeout(() => {
+                actions.clearOptimisticData()
+            }, 5000) // Give subgraph time to update
+
+            return txResponse
+        } catch (error) {
+            console.error('Staking error:', error)
+            // Transaction failed, revert optimistic updates
+            actions.clearOptimisticData()
+            // Re-fetch actual data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+            throw error
+        }
+    }),
+
+    unstake: thunk(async (actions, { signer, amount }, { getStoreActions }) => {
+        const storeActions = getStoreActions()
+        try {
+            const userAddress = await signer.getAddress()
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+            const txData = await stakingManager.populateTransaction.initiateWithdrawal(parseEther(amount))
+            const tx = await handlePreTxGasEstimate(signer, txData)
+
+            const txResponse = await signer.sendTransaction(tx)
+
+            storeActions.transactionsModel.addTransaction({
+                chainId: await signer.getChainId(),
+                hash: txResponse.hash,
+                from: txResponse.from,
+                summary: 'Unstaking KITE',
+                addedTime: new Date().getTime(),
+                originalTx: txResponse,
+            })
+
+            storeActions.popupsModel.setWaitingPayload({
+                title: 'Transaction Submitted',
+                hash: txResponse.hash,
+                status: ActionState.SUCCESS,
+            })
+
+            // Apply optimistic update immediately after user confirms but before sending transaction
+            console.log('Applying optimistic unstake', amount, userAddress)
+
+            actions.applyOptimisticUnstake({ amount, userAddress })
+
+            await txResponse.wait()
+
+            // Transaction successful, now get real data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+
+            // Keep optimistic flag for a while until GraphQL is updated
+            setTimeout(() => {
+                actions.clearOptimisticData()
+            }, 5000) // Give subgraph time to update
+
+            return txResponse
+        } catch (error) {
+            console.error('Unstaking error:', error)
+            // Transaction failed, revert optimistic updates
+            actions.clearOptimisticData()
+            // Re-fetch actual data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+            throw error
+        }
+    }),
+
+    withdraw: thunk(async (actions, { signer }, { getStoreActions }) => {
+        const storeActions = getStoreActions()
+        try {
+            const userAddress = await signer.getAddress()
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+            const txData = await stakingManager.populateTransaction.withdraw()
+            const tx = await handlePreTxGasEstimate(signer, txData)
+
+            const txResponse = await signer.sendTransaction(tx)
+
+            storeActions.transactionsModel.addTransaction({
+                chainId: await signer.getChainId(),
+                hash: txResponse.hash,
+                from: txResponse.from,
+                summary: 'Withdrawing KITE',
+                addedTime: new Date().getTime(),
+                originalTx: txResponse,
+            })
+
+            storeActions.popupsModel.setWaitingPayload({
+                title: 'Transaction Submitted',
+                hash: txResponse.hash,
+                status: ActionState.SUCCESS,
+            })
+
+            // Apply optimistic update immediately after user confirms but before sending transaction
+            console.log('Applying optimistic withdraw', userAddress)
+            actions.applyOptimisticWithdraw({ userAddress })
+
+            await txResponse.wait()
+
+            // Transaction successful, now get real data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+
+            // Keep optimistic flag for a while until GraphQL is updated
+            setTimeout(() => {
+                actions.clearOptimisticData()
+            }, 5000) // Give subgraph time to update
+
+            return txResponse
+        } catch (error) {
+            console.error('Withdrawal error:', error)
+            // Transaction failed, revert optimistic updates
+            actions.clearOptimisticData()
+            // Re-fetch actual data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+            throw error
+        }
+    }),
+
+    cancelWithdrawal: thunk(async (actions, { signer }, { getStoreActions, getState }) => {
+        const storeActions = getStoreActions()
+        try {
+            const userAddress = await signer.getAddress()
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+
+            // Get the pending withdrawal amount before transaction
+            let pendingAmount = '0'
+            const currentState = getState()
+            const userData = currentState.usersStakingData[userAddress.toLowerCase()]
+            if (userData?.pendingWithdrawal?.amount) {
+                pendingAmount = String(userData.pendingWithdrawal.amount)
+            }
+
+            const txData = await stakingManager.populateTransaction.cancelWithdrawal()
+            const tx = await handlePreTxGasEstimate(signer, txData)
+
+            const txResponse = await signer.sendTransaction(tx)
+
+            storeActions.transactionsModel.addTransaction({
+                chainId: await signer.getChainId(),
+                hash: txResponse.hash,
+                from: txResponse.from,
+                summary: 'Cancel Withdrawal',
+                addedTime: new Date().getTime(),
+                originalTx: txResponse,
+            })
+
+            storeActions.popupsModel.setWaitingPayload({
+                title: 'Transaction Submitted',
+                hash: txResponse.hash,
+                status: ActionState.SUCCESS,
+            })
+
+            // Apply optimistic update immediately after user confirms but before sending transaction
+            console.log('Applying optimistic cancel withdrawal', pendingAmount, userAddress)
+            actions.applyOptimisticCancelWithdrawal({ amount: pendingAmount, userAddress })
+
+            await txResponse.wait()
+
+            // Transaction successful, now get real data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+
+            // Keep optimistic flag for a while until GraphQL is updated
+            setTimeout(() => {
+                actions.clearOptimisticData()
+            }, 5000) // Give subgraph time to update
+
+            return txResponse
+        } catch (error) {
+            console.error('Cancel withdrawal error:', error)
+            // Transaction failed, revert optimistic updates
+            actions.clearOptimisticData()
+            // Re-fetch actual data
+            await actions.fetchTotalStaked({ signer })
+            await actions.fetchUserStakedBalance({ signer })
+            throw error
+        }
+    }),
+
+    transactionState: ActionState.NONE,
+    setTransactionState: action((state, payload) => {
+        state.transactionState = payload
+    }),
+
+    cooldownPeriod: '1209600', // Default 21 days in seconds
+    setCooldownPeriod: action((state, payload) => {
+        state.cooldownPeriod = payload
+    }),
+
+    fetchCooldownPeriod: thunk(async (actions, { signer, provider }) => {
+        await retryAsync(async () => {
+            // Use signer if available, otherwise use provider
+            const providerOrSigner = signer || provider
+            if (!providerOrSigner) {
+                throw new Error('Neither signer nor provider available')
+            }
+
+            const stakingManager = new Contract(
+                import.meta.env.VITE_STAKING_MANAGER,
+                StakingManagerABI,
+                providerOrSigner
+            )
+            const params = await stakingManager._params()
+
+            actions.setCooldownPeriod(params.toString())
+        })
+    }),
+
+    userRewards: [],
+    stakingApyData: [],
+    setUserRewards: action((state, payload) => {
+        state.userRewards = payload
+    }),
+    setStakingApyData: action((state, payload) => {
+        state.stakingApyData = payload
+    }),
+    fetchTotalStaked: thunk(async (actions, { signer, provider }) => {
+        await retryAsync(async () => {
+            // Use signer if available, otherwise use provider
+            const providerOrSigner = signer || provider
+            if (!providerOrSigner) {
+                throw new Error('Neither signer nor provider available')
+            }
+
+            const stakingManager = new Contract(
+                import.meta.env.VITE_STAKING_MANAGER,
+                StakingManagerABI,
+                providerOrSigner
+            )
+            const totalStaked = await stakingManager.totalStaked()
+            actions.setTotalStaked(totalStaked.toString())
+        })
+    }),
+    fetchStakingApyData: thunk(async (actions, { signer, provider }) => {
+        await retryAsync(async () => {
+            // Use signer if available, otherwise use provider
+            const providerOrSigner = signer || provider
+            if (!providerOrSigner) {
+                throw new Error('Neither signer nor provider available')
+            }
+
+            const apyData = []
+            const stakingManager = new Contract(
+                import.meta.env.VITE_STAKING_MANAGER,
+                StakingManagerABI,
+                providerOrSigner
+            )
+            // const stakingManagerTotalStaked = await stakingManager.totalStaked()
+            const rewardsCountBigNum = await stakingManager.rewards()
+            const rewardsCount = rewardsCountBigNum.toNumber()
+            for (let i = 0; i < rewardsCount; i++) {
+                const poolData = await stakingManager.rewardTypes(i)
+                const { isActive } = poolData
+                if (isActive) {
+                    const rpContract = new Contract(poolData.rewardPool, RewardPoolABI, providerOrSigner)
+                    const rpRate = await rpContract.rewardRate()
+                    apyData.push({
+                        id: i,
+                        rpRate: rpRate,
+                        rpToken: poolData.rewardToken,
+                    })
+                }
+            }
+            actions.setStakingApyData(apyData)
+        })
+    }),
+
+    fetchUserRewards: thunk(async (actions, { signer }) => {
+        await retryAsync(async () => {
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+            const address = await signer.getAddress()
+            // const stakingManagerTotalStaked = await stakingManager.totalStaked()
+            const rewardsCountBigNum = await stakingManager.rewards()
+            const rewardsCount = rewardsCountBigNum.toNumber()
+
+            const activePools = []
+            const activePoolIndexes: number[] = []
+            for (let i = 0; i < rewardsCount; i++) {
+                const poolData = await stakingManager.rewardTypes(i)
+                const { isActive } = poolData
+                if (isActive) {
+                    //const rpContract = new Contract(poolData.rewardPool, RewardPoolABI, signer)
+                    //const rpRate = await rpContract.rewardRate()
+                    //const rpTotalStaked = await rpContract.totalStaked()
+                    //const ratePerStakedToken = rpRate.div(stakingManagerTotalStaked)
+                    activePools.push({ ...poolData, index: i })
+                    activePoolIndexes.push(i)
+                }
+            }
+
+            const rewardPools = await stakingManager.callStatic.earned(address)
+            const aggregatedRewards: Record<string, ethers.BigNumber> = {}
+            for (let i = 0; i < activePoolIndexes.length; i++) {
+                const poolIndex = activePoolIndexes[i]
+                const { rewardToken, rewardAmount } = rewardPools[poolIndex]
+                if (rewardAmount && rewardAmount.gt(0)) {
+                    if (aggregatedRewards[rewardToken]) {
+                        aggregatedRewards[rewardToken] = aggregatedRewards[rewardToken].add(rewardAmount)
+                    } else {
+                        aggregatedRewards[rewardToken] = rewardAmount
+                    }
+                }
+            }
+            const finalRewardsState: Array<{ id: number; amount: BigNumber; tokenAddress: string }> = Object.entries(
+                aggregatedRewards
+            ).map(([tokenAddress, totalAmountBigNum], index) => {
+                return {
+                    id: index,
+                    amount: totalAmountBigNum,
+                    tokenAddress: tokenAddress,
+                }
+            })
+
+            actions.setUserRewards(finalRewardsState)
+        })
+    }),
+
+    fetchUserStakedBalance: thunk(async (actions, { signer }) => {
+        await retryAsync(async () => {
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+
+            const userAddress = await signer.getAddress()
+            const balance = await stakingManager.stakedBalances(userAddress)
+
+            // Update both the single user state and the mapping
+            actions.setStakedBalance(ethers.utils.formatEther(balance))
+            actions.updateUserStakingData({
+                userId: userAddress.toLowerCase(),
+                data: {
+                    stakedBalance: ethers.utils.formatEther(balance),
+                },
+            })
+
+            return balance
+        })
+    }),
+
+    getReward: thunk(async (actions, { signer }, { getStoreActions }) => {
+        const storeActions = getStoreActions()
+        try {
+            const stakingManager = new Contract(import.meta.env.VITE_STAKING_MANAGER, StakingManagerABI, signer)
+
+            const txData = await stakingManager.populateTransaction.getReward(await signer.getAddress())
+
+            const tx = await handlePreTxGasEstimate(signer, txData)
+            const txResponse = await signer.sendTransaction(tx)
+
+            storeActions.transactionsModel.addTransaction({
+                chainId: await signer.getChainId(),
+                hash: txResponse.hash,
+                from: txResponse.from,
+                summary: 'Claiming Rewards',
+                addedTime: new Date().getTime(),
+                originalTx: txResponse,
+            })
+
+            storeActions.popupsModel.setWaitingPayload({
+                title: 'Transaction Submitted',
+                hash: txResponse.hash,
+                status: ActionState.SUCCESS,
+            })
+
+            await txResponse.wait()
+            actions.fetchUserRewards({ signer }) // Refresh rewards after claim
+            return txResponse
+        } catch (error) {
+            console.error('Reward claim error:', error)
+            throw error
+        }
+    }),
+}

--- a/src/providers/LPDataProvider.tsx
+++ b/src/providers/LPDataProvider.tsx
@@ -1,0 +1,192 @@
+import React, { createContext, useContext, useEffect } from 'react'
+import { useAccount } from 'wagmi'
+import { useStoreActions, useStoreState } from '~/store'
+import type { CurrentUserPosition, PoolData, UserPosition, UserLPBoostMap, UserKiteRatioMap } from '~/model/lpDataModel'
+
+// Define the context type
+type LPDataContextType = {
+    pool: PoolData | null
+    userPositions: UserPosition[] | null
+    userCurrentPositionComposition: CurrentUserPosition[] | null
+    loading: boolean
+    error: any
+    account: string | undefined
+    userLPPositionValue: string
+    userTotalLiquidity: string
+    allPositions: UserPosition[] | null
+    userPositionsMap: Record<string, UserPosition[]>
+    // LP boost data
+    /** Maps user addresses to their calculated LP boost values (1-2x range) */
+    userLPBoostMap: UserLPBoostMap
+    /** Maps user addresses to their KITE staking ratio compared to total staked KITE */
+    userKiteRatioMap: UserKiteRatioMap
+}
+
+// Create context
+const LPDataContext = createContext<LPDataContextType>({
+    pool: null,
+    userPositions: null,
+    userCurrentPositionComposition: null,
+    loading: false,
+    error: null,
+    account: undefined,
+    userLPPositionValue: '0',
+    userTotalLiquidity: '0',
+    allPositions: null,
+    userPositionsMap: {},
+    userLPBoostMap: {},
+    userKiteRatioMap: {},
+})
+
+// Provider component
+export function LPDataProvider({ children }: { children: React.ReactNode }) {
+    const { address: account } = useAccount()
+
+    // Get model state and actions
+    const lpDataState = useStoreState((state) => state.lpDataModel)
+
+    const {
+        pool,
+        userPositions,
+        userCurrentPositionComposition,
+        loading,
+        error,
+        allPositions,
+        userPositionsMap,
+        userLPPositionValue,
+        userPositionValuesMap,
+        userTotalLiquidity,
+        userLPBoostMap,
+        userKiteRatioMap,
+        userTotalLiquidityMap,
+        userCurrentPositionsMap,
+    } = lpDataState
+
+    // Get staking data from staking model
+    const { usersStakingData, totalStaked } = useStoreState((state) => state.stakingModel)
+
+    const {
+        setAccount,
+        fetchPoolData,
+        fetchAllPositions,
+        buildUserPositionsMap,
+        calculateAllCurrentPositions,
+        updateUserData,
+        calculateAllUserLPBoosts,
+    } = useStoreActions((actions) => actions.lpDataModel)
+
+    // Set account in model when it changes
+    useEffect(() => {
+        setAccount(account)
+
+        // If the account changes, update user-specific data
+        if (account) {
+            updateUserData(account)
+        }
+    }, [
+        account,
+        setAccount,
+        allPositions,
+        updateUserData,
+        userCurrentPositionsMap,
+        pool,
+        userPositionValuesMap,
+        userTotalLiquidityMap,
+    ])
+
+    // Calculate LP boosts whenever staking data or LP data changes
+    useEffect(() => {
+        if (usersStakingData && Object.keys(usersStakingData).length > 0 && totalStaked) {
+            calculateAllUserLPBoosts({ usersStakingData, totalStaked })
+        }
+    }, [usersStakingData, totalStaked, calculateAllUserLPBoosts, userTotalLiquidityMap, pool])
+
+    // Initial data fetch - fetch all data once at startup
+    useEffect(() => {
+        // Only fetch all data once at initialization
+        const initializeData = async () => {
+            await fetchPoolData()
+            await fetchAllPositions()
+            await buildUserPositionsMap()
+            await calculateAllCurrentPositions()
+
+            // Update the current user's data if available
+            if (account) {
+                updateUserData(account)
+            }
+
+            // Calculate LP boosts for all users
+            if (usersStakingData && Object.keys(usersStakingData).length > 0 && totalStaked) {
+                calculateAllUserLPBoosts({ usersStakingData, totalStaked })
+            }
+        }
+
+        initializeData()
+
+        // Set up polling every 5 minutes for pool data and all positions
+        const poolDataInterval = setInterval(() => fetchPoolData(), 5 * 60 * 1000)
+        const allPositionsInterval = setInterval(
+            async () => {
+                await fetchAllPositions()
+                await buildUserPositionsMap()
+                await calculateAllCurrentPositions()
+
+                // Update user data after refreshing all positions
+                if (account) {
+                    updateUserData(account)
+                }
+
+                // Also recalculate boosts
+                if (usersStakingData && Object.keys(usersStakingData).length > 0 && totalStaked) {
+                    calculateAllUserLPBoosts({ usersStakingData, totalStaked })
+                }
+            },
+            5 * 60 * 1000
+        )
+
+        return () => {
+            clearInterval(poolDataInterval)
+            clearInterval(allPositionsInterval)
+        }
+    }, [
+        fetchPoolData,
+        fetchAllPositions,
+        buildUserPositionsMap,
+        calculateAllCurrentPositions,
+        updateUserData,
+        account,
+        usersStakingData,
+        totalStaked,
+        calculateAllUserLPBoosts,
+    ])
+
+    return (
+        <LPDataContext.Provider
+            value={{
+                pool,
+                userPositions,
+                userCurrentPositionComposition,
+                loading,
+                error,
+                account,
+                userLPPositionValue,
+                userTotalLiquidity,
+                allPositions,
+                userPositionsMap,
+                userLPBoostMap,
+                userKiteRatioMap,
+            }}
+        >
+            {children}
+        </LPDataContext.Provider>
+    )
+}
+
+// Hook to use the LP data
+export function useLPData() {
+    const context = useContext(LPDataContext)
+    if (context === undefined) {
+        throw new Error('useLPData must be used within a LPDataProvider')
+    }
+    return context
+}

--- a/src/providers/StakingProvider.tsx
+++ b/src/providers/StakingProvider.tsx
@@ -1,0 +1,440 @@
+import React, { createContext, useContext, useEffect, useState, useRef, useMemo } from 'react'
+import { useAccount } from 'wagmi'
+import { useQuery } from '@apollo/client'
+import { gql } from '@apollo/client'
+import { BigNumber } from 'ethers'
+import { formatEther } from 'ethers/lib/utils'
+
+import { useStoreState, useStoreActions } from '~/store'
+import { useEthersSigner, usePublicProvider } from '~/hooks'
+import { UserStakingData as ModelUserStakingData } from '~/model/stakingModel'
+
+// GraphQL queries
+const STAKING_USER_QUERY = gql`
+    query GetStakingUser($id: ID!) {
+        stakingUser(id: $id) {
+            id
+            stakedBalance
+            totalStaked
+            totalWithdrawn
+            stakingPositions {
+                id
+                amount
+                timestamp
+                type
+                transactionHash
+            }
+            rewards {
+                id
+                rewardToken
+                amount
+                destination
+                timestamp
+                transactionHash
+            }
+            pendingWithdrawal {
+                id
+                amount
+                timestamp
+                status
+            }
+        }
+    }
+`
+
+// New query to fetch all staking users
+const ALL_STAKING_USERS_QUERY = gql`
+    query GetAllStakingUsers {
+        stakingUsers(first: 1000) {
+            id
+            stakedBalance
+            totalStaked
+            totalWithdrawn
+            pendingWithdrawal {
+                id
+                amount
+                timestamp
+                status
+            }
+        }
+    }
+`
+
+const STAKING_STATS_QUERY = gql`
+    query GetStakingStats {
+        stakingStatistic(id: "singleton") {
+            totalStaked
+            totalStakers
+            totalRewardsPaid
+        }
+    }
+`
+
+// Types
+export type StakingPosition = {
+    id: string
+    amount: string
+    timestamp: number
+    type: 'STAKE' | 'INITIATE_WITHDRAWAL' | 'CANCEL_WITHDRAWAL' | 'WITHDRAW'
+    transactionHash: string
+}
+
+export type RewardClaim = {
+    id: string
+    rewardToken: string
+    amount: string
+    destination: string
+    timestamp: number
+    transactionHash: string
+}
+
+export type PendingWithdrawal = {
+    id: string
+    amount: string
+    timestamp: number
+    status: 'PENDING' | 'COMPLETED' | 'CANCELLED'
+}
+
+export type StakingData = {
+    stakedBalance: string
+    totalStaked: string
+    totalWithdrawn: string
+    stakingPositions: StakingPosition[]
+    rewards: RewardClaim[]
+    pendingWithdrawal?: PendingWithdrawal
+}
+
+export type StakingStats = {
+    totalStaked: string
+    totalStakers: string
+    totalRewardsPaid: string
+}
+
+const defaultStakingData: StakingData = {
+    stakedBalance: '0',
+    totalStaked: '0',
+    totalWithdrawn: '0',
+    stakingPositions: [],
+    rewards: [],
+}
+
+const defaultStakingStats: StakingStats = {
+    totalStaked: '0',
+    totalStakers: '0',
+    totalRewardsPaid: '0',
+}
+
+// Helper function to format big numbers
+function formatBigNumber(value: string): string {
+    try {
+        return formatEther(BigNumber.from(value))
+    } catch {
+        return '0'
+    }
+}
+
+// Define context type
+interface StakingContextType {
+    stakingData: StakingData
+    stakingStats: StakingStats
+    stakedBalance: string
+    totalStaked: string
+    loading: boolean
+    cooldownPeriod: string
+    userRewards: Array<{
+        id: number
+        amount: BigNumber
+        tokenAddress: string
+    }>
+    stakingApyData: Array<{ id: number; rpRate: BigNumber; rpToken: string }>
+    refetchAll: (params: {
+        stakingAmount?: string
+        unstakingAmount?: string
+        widthdrawAmount?: string
+        cancelWithdrawalAmount?: string
+    }) => Promise<void>
+    usersStakingData: Record<string, ModelUserStakingData>
+    pendingWithdrawals: Record<
+        string,
+        {
+            amount: number
+            timestamp: number
+            status: 'PENDING' | 'COMPLETED' | 'CANCELLED'
+        } | null
+    >
+}
+
+// Create context
+const StakingContext = createContext<StakingContextType | undefined>(undefined)
+
+// Provider component
+export function StakingProvider({ children }: { children: React.ReactNode }) {
+    const { address } = useAccount()
+
+    const [isRefetching, setIsRefetching] = useState(false)
+    const [isInitialDataLoaded, setIsInitialDataLoaded] = useState(false)
+    const provider = usePublicProvider()
+    const signer = useEthersSigner()
+    const { stakingModel: stakingActions } = useStoreActions((actions) => actions)
+    const cooldownPeriod = useStoreState((state) => state.stakingModel.cooldownPeriod)
+    const totalStaked = useStoreState((state) => state.stakingModel.totalStaked)
+    const userRewards = useStoreState((state) => state.stakingModel.userRewards)
+    const stakingApyData = useStoreState((state) => state.stakingModel.stakingApyData)
+    const stakedBalance = useStoreState((state) => state.stakingModel.stakedBalance)
+    const usersStakingData = useStoreState((state) => state.stakingModel.usersStakingData)
+    const pendingWithdrawals = useStoreState((state) => state.stakingModel.pendingWithdrawals)
+    const { setPendingWithdrawals } = useStoreActions((actions) => actions.stakingModel)
+
+    const targetAddress = address ? address : '0x0000000000000000000000000000000000000000'
+
+    // Track when the signer is first available
+    const signerInitialized = useRef(false)
+    // Track when provider is initialized (as fallback)
+    const providerInitialized = useRef(false)
+
+    const {
+        data: userData,
+        loading: userLoading,
+        refetch: refetchUser,
+    } = useQuery(STAKING_USER_QUERY, {
+        variables: { id: targetAddress?.toLowerCase() },
+        skip: !targetAddress,
+        fetchPolicy: 'network-only',
+    })
+
+    const {
+        data: allUsersData,
+        loading: allUsersLoading,
+        refetch: refetchAllUsers,
+    } = useQuery(ALL_STAKING_USERS_QUERY, {
+        fetchPolicy: 'network-only',
+    })
+
+    const {
+        data: statsData,
+        loading: statsLoading,
+        refetch: refetchStats,
+    } = useQuery(STAKING_STATS_QUERY, {
+        fetchPolicy: 'network-only',
+    })
+
+    // Process all users data and update the model
+    useEffect(() => {
+        if (allUsersData?.stakingUsers) {
+            const modelUsersMap: Record<string, ModelUserStakingData> = {}
+            const pendingWithdrawalsMap: Record<
+                string,
+                {
+                    amount: number
+                    timestamp: number
+                    status: 'PENDING' | 'COMPLETED' | 'CANCELLED'
+                } | null
+            > = {}
+
+            allUsersData.stakingUsers.forEach((user: any) => {
+                const formattedBalance = formatBigNumber(user.stakedBalance)
+                const userId = user.id.toLowerCase()
+
+                modelUsersMap[userId] = {
+                    id: userId,
+                    stakedBalance: formattedBalance,
+                }
+
+                if (user.pendingWithdrawal) {
+                    pendingWithdrawalsMap[userId] = {
+                        amount: Number(formatBigNumber(user.pendingWithdrawal.amount)),
+                        timestamp: Number(user.pendingWithdrawal.timestamp),
+                        status: user.pendingWithdrawal.status || 'PENDING',
+                    }
+                } else {
+                    pendingWithdrawalsMap[userId] = null
+                }
+            })
+
+            stakingActions.setUsersStakingData(modelUsersMap)
+            setPendingWithdrawals(pendingWithdrawalsMap)
+        }
+    }, [allUsersData, stakingActions, setPendingWithdrawals])
+
+    // Initial data fetch - only run once when signer becomes available
+    useEffect(() => {
+        async function loadInitialData() {
+            if (signer && !signerInitialized.current) {
+                signerInitialized.current = true
+                try {
+                    await Promise.all([
+                        stakingActions.fetchCooldownPeriod({ signer }),
+                        stakingActions.fetchUserRewards({ signer }),
+                        stakingActions.fetchStakingApyData({ signer }),
+                        stakingActions.fetchTotalStaked({ signer }),
+                        stakingActions.fetchUserStakedBalance({ signer }),
+                    ])
+                    setIsInitialDataLoaded(true)
+                } catch (error) {
+                    console.error('Error loading initial staking data:', error)
+                    // Reset the flag to try again
+                    signerInitialized.current = false
+                }
+            } else if (provider && !signer && !providerInitialized.current) {
+                // Use provider as fallback when signer is not available
+                // This avoids the system crashing when there's no signer
+                providerInitialized.current = true
+                try {
+                    await Promise.all([
+                        stakingActions.fetchCooldownPeriod({ provider }),
+                        stakingActions.fetchStakingApyData({ provider }),
+                        stakingActions.fetchTotalStaked({ provider }),
+                    ])
+                    // Note: We can't fetch user-specific data without a signer
+                    setIsInitialDataLoaded(true)
+                } catch (error) {
+                    console.error('Error loading initial staking data with provider:', error)
+                    providerInitialized.current = false
+                }
+            }
+        }
+
+        loadInitialData()
+    }, [signer, provider, stakingActions])
+
+    // Reset initialization flags when signer or provider changes
+    useEffect(() => {
+        if (!signer) {
+            signerInitialized.current = false
+        }
+        if (!provider) {
+            providerInitialized.current = false
+        }
+        if (!signer && !provider) {
+            setIsInitialDataLoaded(false)
+        }
+    }, [signer, provider])
+
+    // Simplified data merging that prioritizes model data
+    const stakingData = useMemo((): StakingData => {
+        if (!targetAddress) return defaultStakingData
+
+        const userDataFromModel = usersStakingData[targetAddress.toLowerCase()]
+        const userPendingWithdrawal = pendingWithdrawals[targetAddress.toLowerCase()]
+
+        if (!userDataFromModel && !userData?.stakingUser) {
+            return defaultStakingData
+        }
+
+        return {
+            stakedBalance:
+                userDataFromModel?.stakedBalance ||
+                (userData?.stakingUser?.stakedBalance ? formatBigNumber(userData.stakingUser.stakedBalance) : '0'),
+            totalStaked: formatBigNumber(totalStaked),
+            totalWithdrawn: userData?.stakingUser?.totalWithdrawn
+                ? formatBigNumber(userData.stakingUser.totalWithdrawn)
+                : '0',
+            stakingPositions: userData?.stakingUser?.stakingPositions
+                ? userData.stakingUser.stakingPositions.map((pos: any) => ({
+                      ...pos,
+                      amount: formatBigNumber(pos.amount),
+                      timestamp: Number(pos.timestamp),
+                  }))
+                : [],
+            rewards: userData?.stakingUser?.rewards
+                ? userData.stakingUser.rewards.map((reward: any) => ({
+                      ...reward,
+                      amount: formatBigNumber(reward.amount),
+                      timestamp: Number(reward.timestamp),
+                  }))
+                : [],
+            pendingWithdrawal: userPendingWithdrawal
+                ? {
+                      id: 'pending-' + targetAddress.toLowerCase(),
+                      amount: String(userPendingWithdrawal.amount),
+                      timestamp: userPendingWithdrawal.timestamp,
+                      status: userPendingWithdrawal.status,
+                  }
+                : undefined,
+        }
+    }, [userData, totalStaked, usersStakingData, pendingWithdrawals, targetAddress])
+
+    const stakingStats = useMemo((): StakingStats => {
+        if (!statsData?.stakingStatistic) return defaultStakingStats
+
+        const stats = statsData.stakingStatistic
+        return {
+            totalStaked: formatBigNumber(stats.totalStaked),
+            totalStakers: stats.totalStakers.toString(),
+            totalRewardsPaid: formatBigNumber(stats.totalRewardsPaid),
+        }
+    }, [statsData])
+
+    // Simplified refetch function that avoids race conditions
+    /* tslint:disable */
+    /* eslint-disable */
+    const refetchAll = async ({}: // stakingAmount,
+    // unstakingAmount,
+    // widthdrawAmount,
+    // cancelWithdrawalAmount,
+    {
+        stakingAmount?: string
+        unstakingAmount?: string
+        widthdrawAmount?: string
+        cancelWithdrawalAmount?: string
+    } = {}) => {
+        if (!provider) return
+
+        setIsRefetching(true)
+
+        try {
+            // Just refetch GraphQL data since optimistic updates are now handled in the model
+            await Promise.all([refetchUser(), refetchAllUsers(), refetchStats()])
+
+            // Also refresh contract data
+            if (signer) {
+                // If signer is available, fetch all data including user-specific data
+                await Promise.all([
+                    stakingActions.fetchTotalStaked({ signer }),
+                    stakingActions.fetchUserStakedBalance({ signer }),
+                    stakingActions.fetchUserRewards({ signer }),
+                ])
+            } else if (provider) {
+                // Use provider for non-user-specific data
+                // This ensures the application works even without a connected wallet
+                await stakingActions.fetchTotalStaked({ provider })
+            }
+        } catch (error) {
+            console.error('Error refetching staking data:', error)
+        } finally {
+            setIsRefetching(false)
+        }
+    }
+
+    // Improved loading logic that accounts for initial data loading
+    const loading = (userLoading || statsLoading || allUsersLoading || !isInitialDataLoaded) && !isRefetching
+
+    return (
+        <StakingContext.Provider
+            value={{
+                stakingData,
+                stakingStats,
+                stakedBalance,
+                totalStaked,
+                loading,
+                cooldownPeriod,
+                userRewards,
+                stakingApyData,
+                refetchAll,
+                usersStakingData,
+                pendingWithdrawals,
+            }}
+        >
+            {children}
+        </StakingContext.Provider>
+    )
+}
+
+// Hook for using the staking context
+export function useStaking() {
+    const context = useContext(StakingContext)
+    if (context === undefined) {
+        throw new Error('useStaking must be used within a StakingProvider')
+    }
+    return context
+}

--- a/src/services/boostService.ts
+++ b/src/services/boostService.ts
@@ -1,0 +1,269 @@
+/**
+ * Boost Service
+ *
+ * Provides stateless functions for calculating boost values based on staking data
+ * and LP positions.
+ */
+
+/**
+ * Calculate LP boost value for a user
+ *
+ * @param userStakingAmount User's staked amount (KITE)
+ * @param totalStakingAmount Total staked amount (KITE)
+ * @param userLPPosition User's LP position amount
+ * @param totalPoolLiquidity Total pool liquidity
+ * @returns LP boost calculation values
+ */
+export function calculateLPBoost({
+    userStakingAmount,
+    totalStakingAmount,
+    userLPPosition,
+    totalPoolLiquidity,
+}: {
+    userStakingAmount: number
+    totalStakingAmount: number
+    userLPPosition: string | number
+    totalPoolLiquidity: string | number
+}) {
+    // Skip calculation if user has no stake
+    if (userStakingAmount <= 0) return { lpBoost: 1 }
+
+    // Calculate KITE ratio
+    const calculatedKiteRatio =
+        isNaN(totalStakingAmount) || totalStakingAmount === 0 ? 0 : userStakingAmount / totalStakingAmount
+
+    // Calculate LP boost
+    const lpRatio = Number(totalPoolLiquidity) === 0 ? 0 : Number(userLPPosition) / Number(totalPoolLiquidity)
+
+    const lpBoostRaw = lpRatio === 0 ? 1 : calculatedKiteRatio / lpRatio + 1
+    const lpBoost = Math.min(lpBoostRaw, 2)
+
+    return {
+        kiteRatio: calculatedKiteRatio,
+        lpBoost,
+        lpBoostRaw,
+    }
+}
+
+/**
+ * Calculate haiVELO boost value for a user
+ *
+ * @param userStakingAmount User's staked amount (KITE)
+ * @param totalStakingAmount Total staked amount (KITE)
+ * @param userHaiVELODeposited User's haiVELO deposited amount
+ * @param totalHaiVELODeposited Total haiVELO deposited
+ * @returns haiVELO boost calculation values
+ */
+export function calculateHaiVeloBoost({
+    userStakingAmount,
+    totalStakingAmount,
+    userHaiVELODeposited,
+    totalHaiVELODeposited,
+}: {
+    userStakingAmount: number
+    totalStakingAmount: number
+    userHaiVELODeposited: string | number
+    totalHaiVELODeposited: string | number
+}) {
+    // Skip calculation if user has no stake
+    if (userStakingAmount <= 0) return { haiVeloBoost: 1 }
+    if (Number(totalHaiVELODeposited) <= 0) return { haiVeloBoost: 1 }
+
+    // Calculate KITE ratio
+    const calculatedKiteRatio =
+        isNaN(totalStakingAmount) || totalStakingAmount === 0 ? 0 : userStakingAmount / totalStakingAmount
+
+    // Calculate haiVELO boost
+    const haiVeloRatio = Number(userHaiVELODeposited) / Number(totalHaiVELODeposited)
+    const haiVeloBoostRaw = haiVeloRatio === 0 ? 1 : calculatedKiteRatio / haiVeloRatio + 1
+    const haiVeloBoost = Math.min(haiVeloBoostRaw, 2)
+
+    return {
+        kiteRatio: calculatedKiteRatio,
+        haiVeloBoost,
+    }
+}
+
+/**
+ * Combine LP and haiVELO boost values into a net boost value
+ *
+ * @param lpBoost LP boost value
+ * @param haiVeloBoost haiVELO boost value
+ * @param userLPPositionValue Value of user's LP position in USD
+ * @param haiVeloPositionValue Value of user's haiVELO position in USD
+ * @returns Combined boost values
+ */
+export function combineBoostValues({
+    lpBoost,
+    haiVeloBoost,
+    userLPPositionValue,
+    haiVeloPositionValue,
+}: {
+    lpBoost: number
+    haiVeloBoost: number
+    userLPPositionValue: string | number
+    haiVeloPositionValue: string | number
+}) {
+    // Calculate weighted average boost
+    const totalValue = Number(userLPPositionValue) + Number(haiVeloPositionValue)
+    const haiVeloValueRatio = totalValue === 0 ? 0.5 : Number(haiVeloPositionValue) / totalValue
+    const lpValueRatio = totalValue === 0 ? 0.5 : Number(userLPPositionValue) / totalValue
+
+    const weightedHaiVeloBoost = haiVeloBoost * haiVeloValueRatio
+    const weightedLpBoost = lpBoost * lpValueRatio
+
+    const netBoost = weightedHaiVeloBoost + weightedLpBoost
+
+    return {
+        haiVeloBoost,
+        lpBoost,
+        haiVeloValueRatio,
+        lpValueRatio,
+        netBoost,
+    }
+}
+
+/**
+ * Calculate all boost values for a user
+ *
+ * @param userStakingAmount User's staked amount (KITE)
+ * @param totalStakingAmount Total staked amount (KITE)
+ * @param userLPPosition User's LP position amount
+ * @param totalPoolLiquidity Total pool liquidity
+ * @param userLPPositionValue Value of user's LP position in USD
+ * @param userHaiVELODeposited User's haiVELO deposited amount
+ * @param totalHaiVELODeposited Total haiVELO deposited
+ * @param haiVeloPositionValue Value of user's haiVELO position in USD
+ * @returns Boost calculation values
+ */
+export function calculateBoostValues({
+    userStakingAmount,
+    totalStakingAmount,
+    userLPPosition,
+    totalPoolLiquidity,
+    userLPPositionValue,
+    userHaiVELODeposited,
+    totalHaiVELODeposited,
+    haiVeloPositionValue,
+}: {
+    userStakingAmount: number
+    totalStakingAmount: number
+    userLPPosition: string | number
+    totalPoolLiquidity: string | number
+    userLPPositionValue: string | number
+    userHaiVELODeposited: string | number
+    totalHaiVELODeposited: string | number
+    haiVeloPositionValue: string | number
+}) {
+    // Skip calculation if user has no stake
+    if (userStakingAmount <= 0) return { netBoost: 1 }
+
+    // Calculate LP boost using the new function
+    const lpBoostResult = calculateLPBoost({
+        userStakingAmount,
+        totalStakingAmount,
+        userLPPosition,
+        totalPoolLiquidity,
+    })
+
+    // Calculate haiVELO boost using the new function
+    const haiVeloBoostResult = calculateHaiVeloBoost({
+        userStakingAmount,
+        totalStakingAmount,
+        userHaiVELODeposited,
+        totalHaiVELODeposited,
+    })
+
+    // Combine the results using the new function
+    const combinedResult = combineBoostValues({
+        lpBoost: lpBoostResult.lpBoost,
+        haiVeloBoost: haiVeloBoostResult.haiVeloBoost,
+        userLPPositionValue,
+        haiVeloPositionValue,
+    })
+
+    return {
+        kiteRatio: lpBoostResult.kiteRatio, // Both functions calculate the same kiteRatio
+        ...combinedResult,
+    }
+}
+
+/**
+ * Simulate net boost for a hypothetical staking amount
+ *
+ * @param userAfterStakingAmount User's staking amount after hypothetical action
+ * @param totalAfterStakingAmount Total staking amount after hypothetical action
+ * @param userLPPosition User's LP position amount
+ * @param totalPoolLiquidity Total pool liquidity
+ * @param userLPPositionValue Value of user's LP position in USD
+ * @param userHaiVELODeposited User's haiVELO deposited amount
+ * @param totalHaiVELODeposited Total haiVELO deposited
+ * @param haiVeloPositionValue Value of user's haiVELO position in USD
+ * @returns Simulated net boost value
+ */
+export function simulateNetBoost({
+    userAfterStakingAmount,
+    totalAfterStakingAmount,
+    userLPPosition,
+    totalPoolLiquidity,
+    userLPPositionValue,
+    userHaiVELODeposited,
+    totalHaiVELODeposited,
+    haiVeloPositionValue,
+}: {
+    userAfterStakingAmount: number
+    totalAfterStakingAmount: number
+    userLPPosition: string | number
+    totalPoolLiquidity: string | number
+    userLPPositionValue: string | number
+    userHaiVELODeposited: string | number
+    totalHaiVELODeposited: string | number
+    haiVeloPositionValue: string | number
+}) {
+    // Calculate LP boost with simulated staking amounts
+    const lpBoostResult = calculateLPBoost({
+        userStakingAmount: userAfterStakingAmount,
+        totalStakingAmount: totalAfterStakingAmount,
+        userLPPosition,
+        totalPoolLiquidity,
+    })
+
+    // Calculate haiVELO boost with simulated staking amounts
+    const haiVeloBoostResult = calculateHaiVeloBoost({
+        userStakingAmount: userAfterStakingAmount,
+        totalStakingAmount: totalAfterStakingAmount,
+        userHaiVELODeposited,
+        totalHaiVELODeposited,
+    })
+
+    // Combine the boost values
+    const combinedResult = combineBoostValues({
+        lpBoost: lpBoostResult.lpBoost,
+        haiVeloBoost: haiVeloBoostResult.haiVeloBoost,
+        userLPPositionValue,
+        haiVeloPositionValue,
+    })
+
+    return combinedResult.netBoost
+}
+
+/**
+ * Calculate base APR based on daily rewards and position values
+ *
+ * @param totalDailyRewardsInUSD Total daily rewards in USD
+ * @param haiVeloPositionValue Value of user's haiVELO position in USD
+ * @param userLPPositionValue Value of user's LP position in USD
+ * @returns Base APR as a percentage
+ */
+export function calculateBaseAPR({
+    totalDailyRewardsInUSD,
+    haiVeloPositionValue,
+    userLPPositionValue,
+}: {
+    totalDailyRewardsInUSD: number
+    haiVeloPositionValue: string | number
+    userLPPositionValue: string | number
+}) {
+    if (Number(haiVeloPositionValue) + Number(userLPPositionValue) === 0) return 0
+    return (totalDailyRewardsInUSD / (Number(haiVeloPositionValue) + Number(userLPPositionValue))) * 365 * 100
+}

--- a/src/services/lpData.ts
+++ b/src/services/lpData.ts
@@ -1,0 +1,415 @@
+import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
+import { NETWORK_ID } from '~/utils'
+import { Position, FeeAmount, Pool } from '@uniswap/v3-sdk'
+import { Token } from '@uniswap/sdk-core'
+import JSBI from 'jsbi'
+import type { PoolData, UserPosition, CurrentUserPosition } from '~/model/lpDataModel'
+import { calculatePositionValue } from '~/utils/uniswapV3'
+
+// Pool ID from the subgraph
+export const POOL_ID = '0x146b020399769339509c98b7b353d19130c150ec'
+
+const subgraphDefaultUrl =
+    'https://gateway-arbitrum.network.thegraph.com/api/617040e8f75ef522349d70c034f124f2/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5'
+
+// Create the LP client based on env variable
+const lpClient = new ApolloClient({
+    uri: import.meta.env.VITE_LP_SUBGRAPH_URL ? import.meta.env.VITE_LP_SUBGRAPH_URL : subgraphDefaultUrl,
+    cache: new InMemoryCache(),
+})
+
+// Query for pool data
+const POOL_DATA_QUERY = gql`
+    query GetPoolData($id: String!) {
+        pool(id: $id) {
+            id
+            liquidity
+            totalValueLockedToken0
+            totalValueLockedToken1
+            totalValueLockedUSD
+            token0 {
+                symbol
+                decimals
+                id
+            }
+            token1 {
+                symbol
+                decimals
+                id
+            }
+            token0Price
+            token1Price
+            tick
+            sqrtPrice
+        }
+    }
+`
+
+// Query for user positions
+const USER_POSITIONS_QUERY = gql`
+    query GetUserPositions($poolId: String!, $owner: String!) {
+        positions(first: 1000, where: { pool: $poolId, owner: $owner }) {
+            id
+            liquidity
+            depositedToken0
+            depositedToken1
+            withdrawnToken0
+            withdrawnToken1
+            tickLower {
+                tickIdx
+            }
+            tickUpper {
+                tickIdx
+            }
+            owner
+        }
+    }
+`
+
+// Query for all active positions
+const ALL_ACTIVE_POSITIONS_QUERY = gql`
+    query GetAllActivePositions($poolId: String!) {
+        positions(first: 1000, where: { pool: $poolId, liquidity_gt: "0" }) {
+            id
+            liquidity
+            depositedToken0
+            depositedToken1
+            withdrawnToken0
+            withdrawnToken1
+            tickLower {
+                tickIdx
+            }
+            tickUpper {
+                tickIdx
+            }
+            owner
+        }
+    }
+`
+
+/**
+ * Calculates the current amounts of token0 and token1 in a position using Uniswap SDK
+ */
+function calculateCurrentAmounts(
+    liquidity: string,
+    tickLower: number,
+    tickUpper: number,
+    currentTick: number,
+    sqrtPriceX96: string,
+    token0Decimals: number,
+    token1Decimals: number
+): { amount0: string; amount1: string } {
+    try {
+        // Ensure decimals are valid numbers between 0-18
+        const validToken0Decimals =
+            typeof token0Decimals === 'number' && !isNaN(token0Decimals)
+                ? Math.min(Math.max(0, Math.floor(token0Decimals)), 18)
+                : 18
+        const validToken1Decimals =
+            typeof token1Decimals === 'number' && !isNaN(token1Decimals)
+                ? Math.min(Math.max(0, Math.floor(token1Decimals)), 18)
+                : 18
+
+        // Create placeholder tokens - we only need decimals
+        const token0 = new Token(NETWORK_ID, '0x10398abc267496e49106b07dd6be13364d10dc71', validToken0Decimals)
+        const token1 = new Token(NETWORK_ID, '0x4200000000000000000000000000000000000006', validToken1Decimals)
+
+        // Convert liquidity to JSBI (JavaScript BigInt implementation used by Uniswap SDK)
+        const jsbiLiquidity = JSBI.BigInt(liquidity)
+
+        // Convert sqrtPriceX96 to JSBI
+        const sqrtPriceX96JSBI = JSBI.BigInt(sqrtPriceX96)
+
+        // Create a Pool instance
+        const pool = new Pool(
+            token0,
+            token1,
+            FeeAmount.MEDIUM,
+            sqrtPriceX96JSBI,
+            JSBI.BigInt(0), // Liquidity - not important for our calculation
+            currentTick
+        )
+
+        // Create Position instance using the pool
+        const position = new Position({
+            pool,
+            tickLower,
+            tickUpper,
+            liquidity: jsbiLiquidity,
+        })
+
+        // Get amounts
+        const amount0Raw = position.amount0
+        const amount1Raw = position.amount1
+
+        return {
+            amount0: amount0Raw.toFixed(validToken0Decimals),
+            amount1: amount1Raw.toFixed(validToken1Decimals),
+        }
+    } catch (error) {
+        console.error('Error calculating position amounts:', error)
+        return {
+            amount0: '0',
+            amount1: '0',
+        }
+    }
+}
+
+/**
+ * Transforms the initial position data from subgraph to current position composition
+ */
+export function initialPositionToCurrent(
+    position: UserPosition,
+    currentTick: number,
+    sqrtPrice: string,
+    token0Decimals: number,
+    token1Decimals: number
+): CurrentUserPosition {
+    // Convert position data to numbers
+    const liquidity = position.liquidity
+    const tickLower = parseInt(position.tickLower.tickIdx)
+    const tickUpper = parseInt(position.tickUpper.tickIdx)
+
+    // Calculate current token amounts based on current tick and sqrtPrice
+    const { amount0, amount1 } = calculateCurrentAmounts(
+        liquidity,
+        tickLower,
+        tickUpper,
+        currentTick,
+        sqrtPrice,
+        token0Decimals,
+        token1Decimals
+    )
+
+    // Return the new position with current token amounts
+    return {
+        id: position.id,
+        liquidity: position.liquidity,
+        currentToken0: amount0,
+        currentToken1: amount1,
+        tickLower: position.tickLower,
+        tickUpper: position.tickUpper,
+        owner: position.owner,
+    }
+}
+
+/**
+ * Fetches pool data from the subgraph
+ */
+export async function fetchPoolData(): Promise<PoolData | null> {
+    try {
+        const result = await lpClient.query({
+            query: POOL_DATA_QUERY,
+            variables: { id: POOL_ID },
+        })
+
+        const { data } = result
+
+        if (data && data.pool) {
+            return data.pool
+        }
+        return null
+    } catch (err) {
+        console.error('Error fetching LP data:', err)
+        throw err
+    }
+}
+
+/**
+ * Fetches user positions from the subgraph
+ * @deprecated Use fetchAllActivePositions and filter by user instead
+ */
+export async function fetchUserPositions(owner: string): Promise<UserPosition[] | null> {
+    try {
+        // First fetch pool data
+        // const poolResult = await lpClient.query({
+        //     query: POOL_DATA_QUERY,
+        //     variables: {
+        //         id: POOL_ID,
+        //     },
+        // })
+
+        // Then fetch user positions
+        const positionsResult = await lpClient.query({
+            query: USER_POSITIONS_QUERY,
+            variables: {
+                poolId: POOL_ID,
+                owner,
+            },
+        })
+
+        // const { data: poolData } = poolResult
+        const { data: positionsData } = positionsResult
+
+        return positionsData.positions
+    } catch (err) {
+        console.error('Error fetching user positions:', err)
+        throw err
+    }
+}
+
+/**
+ * Fetches all active positions from the subgraph (with liquidity > 0)
+ */
+export async function fetchAllActivePositions(): Promise<UserPosition[] | null> {
+    try {
+        const poolResult = await lpClient.query({
+            query: POOL_DATA_QUERY,
+            variables: {
+                id: POOL_ID,
+            },
+        })
+
+        const { data: poolData } = poolResult
+
+        const result = await lpClient.query({
+            query: ALL_ACTIVE_POSITIONS_QUERY,
+            variables: {
+                poolId: POOL_ID,
+            },
+        })
+
+        const filteredPositions = result.data.positions.filter((position: any) => {
+            const inRange =
+                Number(position.tickLower.tickIdx) <= Number(poolData.pool.tick) &&
+                Number(poolData.pool.tick) < Number(position.tickUpper.tickIdx)
+            return inRange ? position : null
+        })
+
+        if (filteredPositions) {
+            return filteredPositions
+        }
+        return null
+    } catch (err) {
+        console.error('Error fetching all active positions:', err)
+        throw err
+    }
+}
+
+/**
+ * Calculates current position compositions based on pool and user positions
+ */
+export function calculateCurrentPositionComposition(
+    userPositions: UserPosition[],
+    pool: PoolData
+): CurrentUserPosition[] | null {
+    if (!userPositions || !pool || userPositions.length === 0) {
+        return null
+    }
+
+    try {
+        const currentTick = parseInt(pool.tick)
+        return userPositions.map((position) =>
+            initialPositionToCurrent(position, currentTick, pool.sqrtPrice, pool.token0.decimals, pool.token1.decimals)
+        )
+    } catch (err) {
+        console.error('Error calculating current positions:', err)
+        throw err
+    }
+}
+
+/**
+ * Groups positions by user address
+ */
+export function groupPositionsByUser(positions: UserPosition[]): Record<string, UserPosition[]> {
+    return positions.reduce(
+        (grouped, position) => {
+            const owner = position.owner.toLowerCase()
+            if (!grouped[owner]) {
+                grouped[owner] = []
+            }
+            grouped[owner].push(position)
+            return grouped
+        },
+        {} as Record<string, UserPosition[]>
+    )
+}
+
+/**
+ * Gets positions for a specific user from all positions
+ */
+export function getUserPositionsFromAll(allPositions: UserPosition[], userAddress: string): UserPosition[] {
+    if (!userAddress) return []
+    const address = userAddress.toLowerCase()
+    return allPositions.filter((position) => position.owner.toLowerCase() === address)
+}
+
+/**
+ * Calculates the USD value of a position
+ */
+export function calculatePositionValueInUSD(
+    position: UserPosition | CurrentUserPosition,
+    pool: PoolData,
+    token0UsdPrice: number,
+    token1UsdPrice: number
+): number {
+    try {
+        return calculatePositionValue(position, pool, token0UsdPrice, token1UsdPrice)
+    } catch (error) {
+        console.error('Error calculating position value:', error)
+        return 0
+    }
+}
+
+/**
+ * Calculates the total USD value of all positions for a user
+ */
+export function calculateUserPositionsValue(
+    positions: (UserPosition | CurrentUserPosition)[],
+    pool: PoolData,
+    token0UsdPrice: number,
+    token1UsdPrice: number
+): number {
+    if (!positions || positions.length === 0 || !pool) return 0
+
+    return positions.reduce((total, position) => {
+        const positionValue = calculatePositionValueInUSD(position, pool, token0UsdPrice, token1UsdPrice)
+        return total + positionValue
+    }, 0)
+}
+
+/**
+ * Calculate position values for all users
+ */
+export function calculateAllUserPositionValues(
+    userPositionsMap: Record<string, UserPosition[]>,
+    pool: PoolData,
+    token0UsdPrice: number,
+    token1UsdPrice: number
+): Record<string, number> {
+    const result: Record<string, number> = {}
+
+    for (const [userAddress, positions] of Object.entries(userPositionsMap)) {
+        result[userAddress] = calculateUserPositionsValue(positions, pool, token0UsdPrice, token1UsdPrice)
+    }
+
+    return result
+}
+
+/**
+ * Calculate total liquidity provided by a user
+ */
+export function calculateUserTotalLiquidity(positions: UserPosition[]): string {
+    if (!positions || positions.length === 0) return '0'
+
+    return positions
+        .reduce((sum, position) => {
+            return sum + Number(position.liquidity)
+        }, 0)
+        .toString()
+}
+
+/**
+ * Calculate total liquidity for all users
+ */
+export function calculateAllUserTotalLiquidity(
+    userPositionsMap: Record<string, UserPosition[]>
+): Record<string, string> {
+    const result: Record<string, string> = {}
+
+    for (const [userAddress, positions] of Object.entries(userPositionsMap)) {
+        result[userAddress] = calculateUserTotalLiquidity(positions)
+    }
+
+    return result
+}

--- a/src/styles/Button.tsx
+++ b/src/styles/Button.tsx
@@ -32,11 +32,14 @@ export type HaiButtonProps = FlexProps & {
     disabled?: boolean
     $variant?: 'default' | 'unblurred' | 'blueish' | 'greenish' | 'pinkish' | 'yellowish' | 'orangeish'
     $unbordered?: boolean
+    $size?: 'default' | 'small'
 }
+
 export const HaiButton = styled.button.attrs((props: HaiButtonProps) => ({
     $justify: 'space-between',
     $align: 'center',
     $gap: 12,
+    $size: 'default',
     ...props,
 }))<HaiButtonProps>`
     ${FlexStyle}
@@ -49,6 +52,21 @@ export const HaiButton = styled.button.attrs((props: HaiButtonProps) => ({
     white-space: nowrap;
     padding: 8px 20px;
     color: black;
+    border-radius: 999px;
+    transition: all 0.3s ease;
+    cursor: pointer;
+
+    ${({ $size }) =>
+        $size === 'small' &&
+        css`
+            height: 30px;
+            font-size: 11px;
+            padding: 0 12px;
+            font-weight: 500;
+            line-height: 13px;
+            border-width: 0.5px;
+        `}
+
     ${({ theme, $variant = 'default' }) =>
         $variant === 'default'
             ? css`
@@ -58,9 +76,6 @@ export const HaiButton = styled.button.attrs((props: HaiButtonProps) => ({
             : css`
                   background: ${(theme.colors as any)[$variant] || 'transparent'};
               `}
-    border-radius: 999px;
-    transition: all 0.3s ease;
-    cursor: pointer;
 
     &:disabled {
         opacity: 0.7;

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -20,13 +20,25 @@ export type EarnStrategyReward = {
     token: TokenKey
     emission: number
 }
+
+export type BoostAPRData = {
+    totalBoostedValueParticipating: number
+    baseAPR: number
+    myBoost: number
+    myValueParticipating: number
+    myBoostedValueParticipating: number
+    myBoostedShare: number
+    myBoostedAPR: number
+}
+
 export type Strategy = {
     pair: [TokenKey] | [TokenKey, TokenKey]
     rewards: [EarnStrategyReward] | [EarnStrategyReward, EarnStrategyReward]
     tvl: string
-    apy: number
+    apr: number
     userPosition?: string
     strategyType: 'hold' | 'borrow' | 'farm' | 'deposit'
+    boostAPR?: BoostAPRData
 } & (
     | {
           earnPlatform?: undefined

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,6 +10,7 @@ export const {
     VITE_MAINNET_PUBLIC_RPC,
     VITE_TESTNET_PUBLIC_RPC,
     VITE_FLAGSMITH_API_KEY,
+    VITE_LP_SUBGRAPH_URL,
 } = import.meta.env
 
 export enum ChainId {

--- a/src/utils/graphql/client.ts
+++ b/src/utils/graphql/client.ts
@@ -1,10 +1,20 @@
 import { NETWORK_ID, VITE_GRAPH_API_KEY } from '../constants'
 import { ApolloClient, InMemoryCache } from '@apollo/client'
 
+// const uri =
+//     NETWORK_ID === 10
+//         ? 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/hai-mainnet/api'
+//         : 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/sepolia-staking/api'
+
+// const uri =
+//     NETWORK_ID === 10
+//         ? 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/hai-mainnet/version/v1.0.12/api'
+//         : 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/sepolia-staking/api'
+
 const uri =
     NETWORK_ID === 10
-        ? 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/hai-mainnet/api'
-        : 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/hai-sepolia-redeploy/api'
+        ? 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/hai-mainnet-v2/version/v1.0.1/api'
+        : 'https://subgraph.satsuma-prod.com/ea4569e42b10/duuvf2ayrz8e0yxg0udnic--151680/sepolia-staking/api'
 
 export const client = new ApolloClient({
     uri,

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -35,9 +35,30 @@ export function parseRemainingTime(ms: number) {
     }
 }
 
+// Returns cooldown period in days (rounded)
+export function secondsToDays(cooldownPeriod: string): number {
+    // cooldownPeriod is a string in seconds
+    const seconds = Number(cooldownPeriod)
+    return Math.round(seconds / 86400)
+}
+
 export enum Timeframe {
     ONE_DAY,
     ONE_WEEK,
     ONE_MONTH,
     ONE_YEAR,
+}
+
+export function formatTimeFromSeconds(seconds: number): string {
+    const days = Math.floor(seconds / 86400)
+    const hours = Math.floor((seconds % 86400) / 3600)
+    const minutes = Math.floor((seconds % 3600) / 60)
+
+    if (days > 0) {
+        return `${days} ${days === 1 ? 'day' : 'days'}`
+    } else if (hours > 0) {
+        return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+    } else {
+        return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+    }
 }

--- a/src/utils/uniswapV3.ts
+++ b/src/utils/uniswapV3.ts
@@ -1,0 +1,261 @@
+import { NETWORK_ID } from '~/utils'
+import { Position, FeeAmount, Pool } from '@uniswap/v3-sdk'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import JSBI from 'jsbi'
+
+/**
+ * Utility functions for Uniswap V3 position calculations
+ */
+
+/**
+ * Calculate token amounts for a Uniswap V3 position
+ */
+export function calculateAmounts(
+    liquidity: number,
+    tickLower: number,
+    tickUpper: number,
+    currentTick: number,
+    sqrtPrice: number
+) {
+    // Scale down the liquidity to avoid numerical overflows
+    // Uniswap liquidity values are often very large
+    const scaledLiquidity = liquidity / 1e18
+
+    // Convert tick indices to sqrt prices
+    const sqrtPriceLower = Math.sqrt(1.0001 ** tickLower)
+    const sqrtPriceUpper = Math.sqrt(1.0001 ** tickUpper)
+
+    // Note: sqrtPrice from the API is already in the right format, no need for Q64.96 conversion
+    // which was causing massive numerical errors
+    const currentSqrtPrice = parseFloat(sqrtPrice.toString())
+
+    let amount0 = 0
+    let amount1 = 0
+
+    if (currentTick <= tickLower) {
+        // Position is entirely token0
+        amount0 = scaledLiquidity * (1 / sqrtPriceLower - 1 / sqrtPriceUpper)
+    } else if (currentTick >= tickUpper) {
+        // Position is entirely token1
+        amount1 = scaledLiquidity * (sqrtPriceUpper - sqrtPriceLower)
+    } else {
+        // Position contains both tokens
+        amount0 = scaledLiquidity * (1 / currentSqrtPrice - 1 / sqrtPriceUpper)
+        amount1 = scaledLiquidity * (currentSqrtPrice - sqrtPriceLower)
+    }
+
+    return { amount0, amount1 }
+}
+
+/**
+ * Calculate the USD value of a position based on token amounts and prices
+ */
+export function calculateUSDValue(amount0: number, amount1: number, token0UsdPrice: number, token1UsdPrice: number) {
+    // Ensure prices are reasonable (fallback to 1.0 if crazy values)
+    const safeToken0Price =
+        isFinite(token0UsdPrice) && token0UsdPrice > 0 && token0UsdPrice < 1000000 ? token0UsdPrice : 1.0
+
+    const safeToken1Price =
+        isFinite(token1UsdPrice) && token1UsdPrice > 0 && token1UsdPrice < 1000000 ? token1UsdPrice : 1.0
+
+    return amount0 * safeToken0Price + amount1 * safeToken1Price
+}
+
+function calculateCurrentAmounts(
+    liquidity: string,
+    tickLower: number,
+    tickUpper: number,
+    currentTick: number,
+    sqrtPriceX96: string,
+    token0Decimals: number,
+    token1Decimals: number
+): { amount0: CurrencyAmount<Token> | string; amount1: CurrencyAmount<Token> | string } {
+    try {
+        // Ensure decimals are valid numbers between 0-18
+        const validToken0Decimals =
+            typeof token0Decimals === 'number' && !isNaN(token0Decimals)
+                ? Math.min(Math.max(0, Math.floor(token0Decimals)), 18)
+                : 18
+        const validToken1Decimals =
+            typeof token1Decimals === 'number' && !isNaN(token1Decimals)
+                ? Math.min(Math.max(0, Math.floor(token1Decimals)), 18)
+                : 18
+
+        // Create placeholder tokens - we only need decimals
+        const token0 = new Token(NETWORK_ID, '0x10398abc267496e49106b07dd6be13364d10dc71', validToken0Decimals)
+        const token1 = new Token(NETWORK_ID, '0x4200000000000000000000000000000000000006', validToken1Decimals)
+
+        // Convert liquidity to JSBI (JavaScript BigInt implementation used by Uniswap SDK)
+        const jsbiLiquidity = JSBI.BigInt(liquidity)
+
+        // Convert sqrtPriceX96 to JSBI
+        const sqrtPriceX96JSBI = JSBI.BigInt(sqrtPriceX96)
+
+        // Create a Pool instance
+        const pool = new Pool(
+            token0,
+            token1,
+            FeeAmount.MEDIUM,
+            sqrtPriceX96JSBI,
+            JSBI.BigInt(0), // Liquidity - not important for our calculation
+            currentTick
+        )
+
+        // Create Position instance using the pool
+        const position = new Position({
+            pool,
+            tickLower,
+            tickUpper,
+            liquidity: jsbiLiquidity,
+        })
+
+        // Get amounts
+        const amount0Raw = position.amount0
+        const amount1Raw = position.amount1
+
+        // Format amounts as human readable with commas
+        // const formatWithCommas = (value: string): string => {
+        //     const parts = value.split('.')
+        //     parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+        //     return parts.join('.')
+        // }
+
+        // Get human readable values with proper decimals and commas
+        // const amount0Human = formatWithCommas(amount0Raw.toSignificant(6))
+        // const amount1Human = formatWithCommas(amount1Raw.toSignificant(6))
+
+        return {
+            amount0: amount0Raw,
+            amount1: amount1Raw,
+        }
+    } catch (error) {
+        console.error('Error calculating position amounts:', error)
+        throw new Error('Error calculating position amounts')
+    }
+}
+
+// Keep the old function for compatibility
+export function calculatePositionValue(
+    position: {
+        liquidity: string
+        tickLower: { tickIdx: string }
+        tickUpper: { tickIdx: string }
+    },
+    pool: {
+        tick: string
+        sqrtPrice: string
+        token0Price: string
+        token1Price: string
+        totalValueLockedUSD: string
+        liquidity: string
+    },
+    token0UsdPrice: number,
+    token1UsdPrice: number
+) {
+    if (!position || !pool) return 0
+
+    // Convert string values to numbers
+    const liquidity = position.liquidity
+    const tickLower = parseInt(position.tickLower.tickIdx)
+    const tickUpper = parseInt(position.tickUpper.tickIdx)
+    const currentTick = parseInt(pool.tick)
+    const sqrtPrice = pool.sqrtPrice
+
+    if (parseFloat(liquidity) === 0) return 0
+
+    try {
+        // Calculate current token amounts using the SDK-based function
+        // Assuming default decimals of 18 for both tokens
+        const { amount0: amount0Raw, amount1: amount1Raw } = calculateCurrentAmounts(
+            liquidity,
+            tickLower,
+            tickUpper,
+            currentTick,
+            sqrtPrice,
+            18, // token0Decimals - using default of 18
+            18 // token1Decimals - using default of 18
+        )
+
+        // Convert CurrencyAmount objects to numbers for USD calculation
+        let amount0 = 0
+        let amount1 = 0
+
+        if (typeof amount0Raw === 'string') {
+            amount0 = parseFloat(amount0Raw)
+        } else {
+            amount0 = parseFloat(amount0Raw.toFixed(6))
+        }
+
+        if (typeof amount1Raw === 'string') {
+            amount1 = parseFloat(amount1Raw)
+        } else {
+            amount1 = parseFloat(amount1Raw.toFixed(6))
+        }
+
+        // Calculate USD value
+        const value = calculateUSDValue(amount0, amount1, token0UsdPrice, token1UsdPrice)
+
+        // Apply a sanity check - if value is unreasonably large, return a modest estimate
+        if (!isFinite(value) || value > 1000000000) {
+            // Fallback to a simple proportion of pool TVL as a reasonable approximation
+            const poolTVL = parseFloat(pool.totalValueLockedUSD)
+            const poolLiquidity = parseFloat(pool.liquidity)
+            if (poolLiquidity > 0 && isFinite(poolTVL)) {
+                return (parseFloat(liquidity) / poolLiquidity) * poolTVL
+            }
+            return 0
+        }
+
+        return value
+    } catch (error) {
+        console.error('Error calculating position value:', error)
+        return 0
+    }
+}
+
+/**
+ * Creates a Position instance from pool data and position data
+ */
+export function createPositionFromPoolData(
+    poolData: {
+        token0: { id: string; decimals: number }
+        token1: { id: string; decimals: number }
+        tick: string
+        sqrtPrice: string
+        liquidity: string
+    },
+    positionData: {
+        liquidity: string
+        tickLower: { tickIdx: string }
+        tickUpper: { tickIdx: string }
+    }
+): Position {
+    // Create tokens
+    const token0 = new Token(NETWORK_ID, poolData.token0.id, Number(poolData.token0.decimals))
+    const token1 = new Token(NETWORK_ID, poolData.token1.id, Number(poolData.token1.decimals))
+
+    // Convert values to JSBI
+    const jsbiLiquidity = JSBI.BigInt(positionData.liquidity)
+    const sqrtPriceX96JSBI = JSBI.BigInt(poolData.sqrtPrice)
+    const currentTick = parseInt(poolData.tick)
+    const tickLower = parseInt(positionData.tickLower.tickIdx)
+    const tickUpper = parseInt(positionData.tickUpper.tickIdx)
+
+    // Create pool instance
+    const pool = new Pool(
+        token0,
+        token1,
+        FeeAmount.MEDIUM,
+        sqrtPriceX96JSBI,
+        JSBI.BigInt(poolData.liquidity), // Liquidity - not important for our calculation
+        currentTick
+    )
+
+    // Create and return position instance
+    return new Position({
+        pool,
+        tickLower,
+        tickUpper,
+        liquidity: jsbiLiquidity,
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/abi@^5.5.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
+  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/abstract-provider@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
@@ -1642,6 +1657,19 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
+"@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+
 "@ethersproject/abstract-signer@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
@@ -1663,6 +1691,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/address@5.4.0":
   version "5.4.0"
@@ -1686,6 +1725,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
+"@ethersproject/address@^5.0.2", "@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+
 "@ethersproject/base64@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
@@ -1699,6 +1749,13 @@
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
 
 "@ethersproject/basex@5.4.0":
   version "5.4.0"
@@ -1734,6 +1791,15 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
@@ -1748,6 +1814,13 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/constants@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
@@ -1761,6 +1834,13 @@
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
 
 "@ethersproject/contracts@5.4.1":
   version "5.4.1"
@@ -1831,6 +1911,21 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/hdnode@5.4.0":
   version "5.4.0"
@@ -1922,6 +2017,14 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
@@ -1931,6 +2034,11 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
 "@ethersproject/networks@5.4.2":
   version "5.4.2"
@@ -1945,6 +2053,13 @@
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/pbkdf2@5.4.0":
   version "5.4.0"
@@ -1975,6 +2090,13 @@
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/providers@5.4.5":
   version "5.4.5"
@@ -2059,6 +2181,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/sha2@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
@@ -2075,6 +2205,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz#8954a613bb78dac9b46829c0a95de561ef74e5e1"
+  integrity sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.4.0":
@@ -2101,6 +2240,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    bn.js "^5.2.1"
+    elliptic "6.6.1"
+    hash.js "1.1.7"
+
 "@ethersproject/solidity@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.4.0.tgz#1305e058ea02dc4891df18b33232b11a14ece9ec"
@@ -2124,6 +2275,18 @@
     "@ethersproject/sha2" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/solidity@^5.0.9":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz#429bb9fcf5521307a9448d7358c26b93695379b9"
+  integrity sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/strings@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
@@ -2141,6 +2304,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/transactions@5.4.0":
   version "5.4.0"
@@ -2171,6 +2343,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
+
+"@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
 
 "@ethersproject/units@5.4.0":
   version "5.4.0"
@@ -2253,6 +2440,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
+  dependencies:
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/wordlists@5.4.0":
   version "5.4.0"
@@ -2828,6 +3026,16 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@openzeppelin/contracts@3.4.1-solc-0.7-2":
+  version "3.4.1-solc-0.7-2"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
+  integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
+
+"@openzeppelin/contracts@3.4.2-solc-0.7":
+  version "3.4.2-solc-0.7"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz#38f4dbab672631034076ccdf2f3201fab1726635"
+  integrity sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==
 
 "@openzeppelin/contracts@4.6.0":
   version "4.6.0"
@@ -4260,15 +4468,68 @@
     "@typescript-eslint/types" "6.8.0"
     eslint-visitor-keys "^3.4.1"
 
-"@uniswap/v2-core@1.0.1":
+"@uniswap/lib@^4.0.1-alpha":
+  version "4.0.1-alpha"
+  resolved "https://registry.npmjs.org/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"
+  integrity sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==
+
+"@uniswap/sdk-core@^7.7.1", "@uniswap/sdk-core@^7.7.2":
+  version "7.7.2"
+  resolved "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz#dc3a9b63b343640754860dce05d06972815eaee6"
+  integrity sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+
+"@uniswap/swap-router-contracts@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@uniswap/swap-router-contracts/-/swap-router-contracts-1.3.1.tgz#0ebbb93eb578625618ed9489872de381f9c66fb4"
+  integrity sha512-mh/YNbwKb7Mut96VuEtL+Z5bRe0xVIbjjiryn+iMMrK2sFKhR4duk/86mEz0UO5gSx4pQIw9G5276P5heY/7Rg==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.2-solc-0.7"
+    "@uniswap/v2-core" "^1.0.1"
+    "@uniswap/v3-core" "^1.0.0"
+    "@uniswap/v3-periphery" "^1.4.4"
+    dotenv "^14.2.0"
+    hardhat-watcher "^2.1.1"
+
+"@uniswap/v2-core@1.0.1", "@uniswap/v2-core@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
   integrity sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==
+
+"@uniswap/v3-core@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.0.tgz#6c24adacc4c25dceee0ba3ca142b35adbd7e359d"
+  integrity sha512-kSC4djMGKMHj7sLMYVnn61k9nu+lHjMIxgg9CDQT+s2QYLoA56GbSK9Oxr+qJXzzygbkrmuY6cwgP6cW2JXPFA==
 
 "@uniswap/v3-core@1.0.2-solc-0.8-simulate":
   version "1.0.2-solc-0.8-simulate"
   resolved "https://registry.yarnpkg.com/@uniswap/v3-core/-/v3-core-1.0.2-solc-0.8-simulate.tgz#77fb42f2b502b4fec81844736d039fc059e8688c"
   integrity sha512-ALAZbsb3wvUrRzeAjrTKjv1fH7UrueJ/+D8uX4yintXHxxzbnnp78Kis2pa4D26cFQ72rwM3DrZpUES9rhsEuQ==
+
+"@uniswap/v3-core@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@uniswap/v3-core/-/v3-core-1.0.1.tgz#b6d2bdc6ba3c3fbd610bdc502395d86cd35264a0"
+  integrity sha512-7pVk4hEm00j9tc71Y9+ssYpO6ytkeI0y7WE9P6UcmNzhxPePwyAxImuhVsTqWK9YFvzgtvzJHi64pBl4jUzKMQ==
+
+"@uniswap/v3-periphery@^1.0.1", "@uniswap/v3-periphery@^1.1.1", "@uniswap/v3-periphery@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.npmjs.org/@uniswap/v3-periphery/-/v3-periphery-1.4.4.tgz#d2756c23b69718173c5874f37fd4ad57d2f021b7"
+  integrity sha512-S4+m+wh8HbWSO3DKk4LwUCPZJTpCugIsHrWR86m/OrUyvSqGDTXKFfc2sMuGXCZrD1ZqO3rhQsKgdWg3Hbb2Kw==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.2-solc-0.7"
+    "@uniswap/lib" "^4.0.1-alpha"
+    "@uniswap/v2-core" "^1.0.1"
+    "@uniswap/v3-core" "^1.0.0"
+    base64-sol "1.0.1"
 
 "@uniswap/v3-periphery@https://github.com/Uniswap/v3-periphery.git#0.8":
   version "1.4.2-solc-0.8"
@@ -4279,6 +4540,29 @@
     "@uniswap/v3-core" "1.0.2-solc-0.8-simulate"
     base64-sol "1.1.0"
     hardhat-watcher "^2.1.1"
+
+"@uniswap/v3-sdk@^3.25.2":
+  version "3.25.2"
+  resolved "https://registry.npmjs.org/@uniswap/v3-sdk/-/v3-sdk-3.25.2.tgz#cb6ee174b58d86a3b3b18b3ba72f662e58c415da"
+  integrity sha512-0oiyJNGjUVbc958uZmAr+m4XBCjV7PfMs/OUeBv+XDl33MEYF/eH86oBhvqGDM8S/cYaK55tCXzoWkmRUByrHg==
+  dependencies:
+    "@ethersproject/abi" "^5.5.0"
+    "@ethersproject/solidity" "^5.0.9"
+    "@uniswap/sdk-core" "^7.7.1"
+    "@uniswap/swap-router-contracts" "^1.3.0"
+    "@uniswap/v3-periphery" "^1.1.1"
+    "@uniswap/v3-staker" "1.0.0"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+
+"@uniswap/v3-staker@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@uniswap/v3-staker/-/v3-staker-1.0.0.tgz#9a6915ec980852479dfc903f50baf822ff8fa66e"
+  integrity sha512-JV0Qc46Px5alvg6YWd+UIaGH9lDuYG/Js7ngxPit1SPaIP30AlVer1UYB7BRYeUVVxE+byUyIeN5jeQ7LLDjIw==
+  dependencies:
+    "@openzeppelin/contracts" "3.4.1-solc-0.7-2"
+    "@uniswap/v3-core" "1.0.0"
+    "@uniswap/v3-periphery" "^1.0.1"
 
 "@vanilla-extract/css@1.9.1":
   version "1.9.1"
@@ -5469,6 +5753,11 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+base64-sol@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/base64-sol/-/base64-sol-1.0.1.tgz#91317aa341f0bc763811783c5729f1c2574600f6"
+  integrity sha512-ld3cCNMeXt4uJXmLZBHFGMvVpK9KsLVEhPpFRXnvSVAqABKbuNZg/+dsq3NuM+wxFLb/UrVkz7m1ciWmkMfTbg==
+
 base64-sol@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/base64-sol/-/base64-sol-1.1.0.tgz#39c3c91a35790b6eb3b8e73114b46bacf0fc2865"
@@ -5478,6 +5767,11 @@ bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 bigint-buffer@^1.1.5:
   version "1.1.5"
@@ -6289,6 +6583,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+decimal.js-light@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
+
 decimal.js@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
@@ -6488,6 +6787,11 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
+dotenv@^14.2.0:
+  version "14.3.2"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz#7c30b3a5f777c79a3429cb2db358eef6751e8369"
+  integrity sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==
+
 "ds-test@https://github.com/dapphub/ds-test":
   version "1.0.0"
   uid e282159d5170298eb2455a6c05280ab5a73a4ef0
@@ -6551,6 +6855,19 @@ elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
+elliptic@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -8812,6 +9129,11 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsbi@^3.1.4:
+  version "3.2.5"
+  resolved "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz#b37bb90e0e5c2814c1c2a1bcd8c729888a2e37d6"
+  integrity sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ==
 
 jsc-android@^250231.0.0:
   version "250231.0.0"
@@ -11752,7 +12074,7 @@ time-span@4.0.0:
   dependencies:
     convert-hrtime "^3.0.0"
 
-tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.2, tiny-invariant@^1.1.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
@@ -11793,6 +12115,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz#7a043fd2dfbe9021a4e36e508835ba32056739d8"
+  integrity sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
* feat: basics of the staking page added

* feat: staking details container added

* feat: staking overview component completed

* feat:staking manager added

* feat: staking data and actions added

* feat: staking ui completed

* chour: iterating over feedback of the staking UI

* feat: lp position data added

* feat: added hai-velo deposit boosts

* feat: wip

* fix: fixed the LP position composition update

* feat: wip

* feat: wip

* fix: minor bug fixes

* fix: wip

* fix: added retry option to staking model

* fix: fixed simulation when there is nothing happening

* fix: KITE -> sKITE in simulation

* fix: min decimal fixed

* fix: all items fixed

* fix: minor fixes

* feat: bump subgraph version

* fix: stKite label fixed

* fix: boost division on 0 fixed

* debug: added the debugging for production query

* fix: dynamic cooldown fixed

* debug: added debug log for lp production bug

* debug: add additional log for production lp subgraph

* fix: fixed default lp subgraph url

* fix: fixed intention header

* fix: minor bug fix on intetion header for stake spacing

* fix: fixed static net boost value on intention header

* fix: removed mentions of governance/voting-power

* fix: my staking apy -> staking apr

* fix: staking apr tooltip data fixed

* fix: fixed activity redirecting users to sepolia explorer

* chor: improved the reactivity of the actions

* fix: staking tvl bug fix

* fix: withdrawal bug fixed

* fix: improved staking tvl $ amount

* fix: boost simulation fixed

* fix: fixed erc20 abi import

* feat: added tooltip for the net boost

* fix: fixed progress indicator simulation value

* feat: bump subgraph version

* feat: brand new subgraph

* chor: start of the refactoring of staking ui

* chor: clean up useBoost

* chor: lp data refactored

* feat: added all user positions to lp data

* chor: refactored lp logic from useBoost to lp model data flow

* chor: refactored stake data into proper provider and model

* chor: refactored boost calculation on its own service

* feat: added staking data for all of the users

* Update staking functionality

* fix: bug fixes

* fix: my stKite simulation bug fixes

* chor: handled small logs

* feat: centeralized staking summary data

* feat: better optimistic ui

* chor: clean up of staking model

* feat: added optimistic response for the cancelling

* fix: fixed user staking data value

* fix: fixed fetchUserStakedBalance

* feat: hai-weth earn row compeleted

* feat: earn page completed

* feat: added op rewards banner

* fix: fixed haiweth boost calculation

* feat: vault page boost feature added

* fix: fixed optimistic ui

* fix: fixed kite claim optimistic ui bug

* fix: fixed the stkite reatio in vault page

* fix: fixed earn page inconsistency problem

* fix: minor ui fixes

* feat: added the reward price to the staking rewards stat

* fix: fixed my rewards apr for non boosted

* feat: update subgraph

* fix: reward division to zero bug fixed

* fix: not boosted apr showed fixed

* feat: added the boost change in the confirmation

* fix: not LP data loading fixed

* chor: updated the default cooldown

* fix: added missing dependency for the set account effect

* chor: removed debug log

* feat: add 2 retries for user data fetching

* fix: fixed unreliable loading of my boosted value

* fix: fixed haivelo apr

* fix: fixed the staking apr percent

* fix: fixed staking APR accuracy

* chor: removed unnecessary logs

* fix: fixed infinite staking loading when not connected

* fix: fixed active positions

* fix: fixed lp boost formula

* fix: revert back to initial formula

* chore: fix linting issues

* chore: fix linting issues

* chore: fix linting issues

---------