### PR TITLE
chore: update minting rewards

### DIFF
--- a/src/hooks/useMinterVaults.tsx
+++ b/src/hooks/useMinterVaults.tsx
@@ -64,6 +64,7 @@ export type MinterVaultsData = {
 const minterVaultCollaterals = [
     'HAIVELO',
     'HAIVELOV2',
+    'HAIAERO',
     'ALETH',
     'YV-VELO-ALETH-WETH',
     'YV-VELO-MSETH-WETH',

--- a/src/services/rewards/__tests__/vaultRewardsService.test.ts
+++ b/src/services/rewards/__tests__/vaultRewardsService.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { getVaultSchedule, computeVaultApr } from '../vaultRewardsService'
 
 describe('vaultRewardsService.getVaultSchedule', () => {
-    it('returns schedule entries only for positive rewards', () => {
-        const res = getVaultSchedule('ALETH')
-        expect(Array.isArray(res)).toBe(true)
-        expect(res.find((r) => r.token === 'KITE')?.dailyAmount).toBeGreaterThan(0)
+    it.each(['ALETH', 'YV-VELO-ALETH-WETH'])('returns no schedule entries for %s', (collateral) => {
+        expect(getVaultSchedule(collateral)).toEqual([])
+    })
+
+    it('returns the configured haiAERO minting reward', () => {
+        expect(getVaultSchedule('HAIAERO')).toEqual([{ token: 'KITE', dailyAmount: 50 }])
     })
 })
 

--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -9,11 +9,11 @@ export const REWARDS = {
             OP: 0,
         },
         ALETH: {
-            KITE: 50,
+            KITE: 0,
             OP: 0,
         },
         'YV-VELO-ALETH-WETH': {
-            KITE: 25,
+            KITE: 0,
             OP: 0,
         },
         'YV-VELO-MSETH-WETH': {
@@ -54,7 +54,7 @@ export const REWARDS = {
             OP: 0,
         },
         HAIAERO: {
-            KITE: 0,
+            KITE: 50,
             OP: 0,
         },
         // Testnet


### PR DESCRIPTION
## Summary

- set ALETH minting rewards to 0 KITE per day
- set YV-VELO-ALETH-WETH minting rewards to 0 KITE per day
- set haiAERO minting rewards to 50 KITE per day
- include HAIAERO in the minter-vault query so its Earn boost and APR use live vault data
- update reward schedule regression coverage

## Why

The Earn-page Daily Emissions tooltip still showed the previous ALETH and YV-VELO-ALETH-WETH allocations, while haiAERO had no configured KITE minting reward. HAIAERO was also absent from the query that supplies vault data for the Earn boost/APR calculation.

## User impact

ALETH and YV-VELO-ALETH-WETH no longer appear as active minting-reward strategies, and the haiAERO minting strategy now displays 50 KITE per day with a coherent boost/APR calculation.

## Validation

- `yarn test` — 57 files, 154 tests passed using the repository CI environment
- `yarn build`
- targeted ESLint and Prettier checks
- `git diff --check`
